### PR TITLE
Fix for prefab duplication bug

### DIFF
--- a/Source/Engine/Serialization/JsonTools.cpp
+++ b/Source/Engine/Serialization/JsonTools.cpp
@@ -10,7 +10,7 @@
 #include "Engine/Utilities/Encryption.h"
 
 
-void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, const Dictionary<Guid, Guid>& mapping, const char* currentFieldName = nullptr)
+void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, const Dictionary<Guid, Guid>& mapping)
 {
     if (obj.IsObject())
     {
@@ -73,100 +73,13 @@ void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, c
         }
     }
 }
-//
-//void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, const Dictionary<Guid, Guid>& mapping, const char* currentFieldName = nullptr)
-//{
-//    if (obj.IsObject())
-//    {
-//        for (rapidjson_flax::Value::MemberIterator i = obj.MemberBegin(); i != obj.MemberEnd(); ++i)
-//        {
-//            ChangeIds(i->value, document, mapping, i->name.GetString());
-//        }
-//    }
-//    else if (obj.IsArray())
-//    {
-//        for (rapidjson::SizeType i = 0; i < obj.Size(); i++)
-//        {
-//            ChangeIds(obj[i], document, mapping, currentFieldName);
-//        }
-//    }
-//    else if (obj.IsString() && obj.GetStringLength() == 32)
-//    {
-//        // SAFETY CHECK: Never change Name fields or other non-ID fields
-//        if (currentFieldName != nullptr)
-//        {
-//            const char* fieldName = currentFieldName;
-//            
-//            // Skip Name fields entirely
-//            if (strcmp(fieldName, "Name") == 0)
-//            {
-//                return;
-//            }
-//            
-//            // Only change known ID fields
-//            bool isIdField = (strcmp(fieldName, "ID") == 0) ||
-//                           (strcmp(fieldName, "ParentID") == 0) ||
-//                           (strcmp(fieldName, "PrefabID") == 0) ||
-//                           (strcmp(fieldName, "PrefabObjectID") == 0) ||
-//                           (strstr(fieldName, "ID") != nullptr && 
-//                            (strstr(fieldName, "ID") == fieldName + strlen(fieldName) - 2)); // Ends with "ID"
-//            
-//            if (!isIdField)
-//            {
-//                return; // Skip non-ID fields
-//            }
-//        }
-//        
-//        // Only process if this looks like a valid GUID and exists in mapping
-//        auto value = JsonTools::GetGuid(obj);
-//        if (value.IsValid() && mapping.TryGet(value, value))
-//        {
-//            // Existing optimized GUID formatting code
-//            char buffer[32] =
-//            {
-//            // @formatter:off
-//                '0','0','0','0','0','0','0','0','0','0',
-//                '0','0','0','0','0','0','0','0','0','0',
-//                '0','0','0','0','0','0','0','0','0','0',
-//                '0','0'
-//            // @formatter:on
-//            };
-//            static const char* digits = "0123456789abcdef";
-//            uint32 n = value.A;
-//            char* p = buffer + 7;
-//            do
-//            {
-//                *p-- = digits[n & 0xf];
-//            } while ((n >>= 4) != 0);
-//            n = value.B;
-//            p = buffer + 15;
-//            do
-//            {
-//                *p-- = digits[n & 0xf];
-//            } while ((n >>= 4) != 0);
-//            n = value.C;
-//            p = buffer + 23;
-//            do
-//            {
-//                *p-- = digits[n & 0xf];
-//            } while ((n >>= 4) != 0);
-//            n = value.D;
-//            p = buffer + 31;
-//            do
-//            {
-//                *p-- = digits[n & 0xf];
-//            } while ((n >>= 4) != 0);
-//            obj.SetString(buffer, 32, document.GetAllocator());
-//        }
-//    }
-//}
 
 void JsonTools::ChangeIds(Document& doc, const Dictionary<Guid, Guid>& mapping)
 {
     if (mapping.IsEmpty())
         return;
     PROFILE_CPU();
-    ::ChangeIds(doc, doc, mapping, nullptr); // Pass nullptr for root level
+    ::ChangeIds(doc, doc, mapping);
 }
 
 Float2 JsonTools::GetFloat2(const Value& value)

--- a/Source/Engine/Serialization/JsonTools.cpp
+++ b/Source/Engine/Serialization/JsonTools.cpp
@@ -9,62 +9,40 @@
 #include "Engine/Scripting/ScriptingObjectReference.h"
 #include "Engine/Utilities/Encryption.h"
 
+
 void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, const Dictionary<Guid, Guid>& mapping, const char* currentFieldName = nullptr)
 {
     if (obj.IsObject())
     {
         for (rapidjson_flax::Value::MemberIterator i = obj.MemberBegin(); i != obj.MemberEnd(); ++i)
         {
-            ChangeIds(i->value, document, mapping, i->name.GetString());
+            ChangeIds(i->value, document, mapping);
         }
     }
     else if (obj.IsArray())
     {
         for (rapidjson::SizeType i = 0; i < obj.Size(); i++)
         {
-            ChangeIds(obj[i], document, mapping, currentFieldName);
+            ChangeIds(obj[i], document, mapping);
         }
     }
     else if (obj.IsString() && obj.GetStringLength() == 32)
     {
-        // SAFETY CHECK: Never change Name fields or other non-ID fields
-        if (currentFieldName != nullptr)
-        {
-            const char* fieldName = currentFieldName;
-            
-            // Skip Name fields entirely
-            if (strcmp(fieldName, "Name") == 0)
-            {
-                return;
-            }
-            
-            // Only change known ID fields
-            bool isIdField = (strcmp(fieldName, "ID") == 0) ||
-                           (strcmp(fieldName, "ParentID") == 0) ||
-                           (strcmp(fieldName, "PrefabID") == 0) ||
-                           (strcmp(fieldName, "PrefabObjectID") == 0) ||
-                           (strstr(fieldName, "ID") != nullptr && 
-                            (strstr(fieldName, "ID") == fieldName + strlen(fieldName) - 2)); // Ends with "ID"
-            
-            if (!isIdField)
-            {
-                return; // Skip non-ID fields
-            }
-        }
-        
-        // Only process if this looks like a valid GUID and exists in mapping
         auto value = JsonTools::GetGuid(obj);
         if (value.IsValid() && mapping.TryGet(value, value))
         {
-            // Existing optimized GUID formatting code
+            // Unoptimized version:
+            //obj.SetString(value.ToString(Guid::FormatType::N).ToSTD().c_str(), 32, document.GetAllocator());
+
+            // Optimized version:
             char buffer[32] =
             {
-            // @formatter:off
-                '0','0','0','0','0','0','0','0','0','0',
-                '0','0','0','0','0','0','0','0','0','0',
-                '0','0','0','0','0','0','0','0','0','0',
-                '0','0'
-            // @formatter:on
+                // @formatter:off
+                    '0','0','0','0','0','0','0','0','0','0',
+                    '0','0','0','0','0','0','0','0','0','0',
+                    '0','0','0','0','0','0','0','0','0','0',
+                    '0','0'
+                    // @formatter:on
             };
             static const char* digits = "0123456789abcdef";
             uint32 n = value.A;
@@ -95,6 +73,93 @@ void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, c
         }
     }
 }
+//
+//void ChangeIds(rapidjson_flax::Value& obj, rapidjson_flax::Document& document, const Dictionary<Guid, Guid>& mapping, const char* currentFieldName = nullptr)
+//{
+//    if (obj.IsObject())
+//    {
+//        for (rapidjson_flax::Value::MemberIterator i = obj.MemberBegin(); i != obj.MemberEnd(); ++i)
+//        {
+//            ChangeIds(i->value, document, mapping, i->name.GetString());
+//        }
+//    }
+//    else if (obj.IsArray())
+//    {
+//        for (rapidjson::SizeType i = 0; i < obj.Size(); i++)
+//        {
+//            ChangeIds(obj[i], document, mapping, currentFieldName);
+//        }
+//    }
+//    else if (obj.IsString() && obj.GetStringLength() == 32)
+//    {
+//        // SAFETY CHECK: Never change Name fields or other non-ID fields
+//        if (currentFieldName != nullptr)
+//        {
+//            const char* fieldName = currentFieldName;
+//            
+//            // Skip Name fields entirely
+//            if (strcmp(fieldName, "Name") == 0)
+//            {
+//                return;
+//            }
+//            
+//            // Only change known ID fields
+//            bool isIdField = (strcmp(fieldName, "ID") == 0) ||
+//                           (strcmp(fieldName, "ParentID") == 0) ||
+//                           (strcmp(fieldName, "PrefabID") == 0) ||
+//                           (strcmp(fieldName, "PrefabObjectID") == 0) ||
+//                           (strstr(fieldName, "ID") != nullptr && 
+//                            (strstr(fieldName, "ID") == fieldName + strlen(fieldName) - 2)); // Ends with "ID"
+//            
+//            if (!isIdField)
+//            {
+//                return; // Skip non-ID fields
+//            }
+//        }
+//        
+//        // Only process if this looks like a valid GUID and exists in mapping
+//        auto value = JsonTools::GetGuid(obj);
+//        if (value.IsValid() && mapping.TryGet(value, value))
+//        {
+//            // Existing optimized GUID formatting code
+//            char buffer[32] =
+//            {
+//            // @formatter:off
+//                '0','0','0','0','0','0','0','0','0','0',
+//                '0','0','0','0','0','0','0','0','0','0',
+//                '0','0','0','0','0','0','0','0','0','0',
+//                '0','0'
+//            // @formatter:on
+//            };
+//            static const char* digits = "0123456789abcdef";
+//            uint32 n = value.A;
+//            char* p = buffer + 7;
+//            do
+//            {
+//                *p-- = digits[n & 0xf];
+//            } while ((n >>= 4) != 0);
+//            n = value.B;
+//            p = buffer + 15;
+//            do
+//            {
+//                *p-- = digits[n & 0xf];
+//            } while ((n >>= 4) != 0);
+//            n = value.C;
+//            p = buffer + 23;
+//            do
+//            {
+//                *p-- = digits[n & 0xf];
+//            } while ((n >>= 4) != 0);
+//            n = value.D;
+//            p = buffer + 31;
+//            do
+//            {
+//                *p-- = digits[n & 0xf];
+//            } while ((n >>= 4) != 0);
+//            obj.SetString(buffer, 32, document.GetAllocator());
+//        }
+//    }
+//}
 
 void JsonTools::ChangeIds(Document& doc, const Dictionary<Guid, Guid>& mapping)
 {


### PR DESCRIPTION
There is a bug where where duplicating a prefab doesn't preserve references. This was a regression introduced in https://github.com/LOOPDISK/FlaxEngine/commit/6eded83dabe8687bfd918d66617014eb886d9348, which was need to fix the importer. Recent engine update makes that fix no longer necessary, so this fix reverts that previous commit.

⚠️ I'm adding everyone as a reviewer here, simply so you see it and know to update engine eventually. This is practice for documenting changes so we can all get on the same page more easily.

Note that this also brings in updates from the upstream master FlaxEngine. In the future, this should probably be done in a separate pull request ideally.

Also, this is a second PR attempt, I messed up the first one since I merged into `main` instead of `derelict-mods`. This should fix that.