### PR TITLE
Fixed an issue with small shadows getting culled incorrectly

### DIFF
--- a/Source/Engine/Foliage/Foliage.cpp
+++ b/Source/Engine/Foliage/Foliage.cpp
@@ -295,7 +295,7 @@ void Foliage::DrawCluster(DrawContext& context, FoliageCluster* cluster, DrawCal
             sphere.Center -= context.ViewOrigin;
             if (Float3::Distance(context.LodView.Position, sphere.Center) - (float)sphere.Radius < instance.CullDistance &&
                 context.RenderContext.View.CullingFrustum.Intersects(sphere) &&
-                RenderTools::ComputeBoundsScreenRadiusSquared(sphere.Center, sphere.Radius, context.RenderContext.View) * context.ViewScreenSizeSq >= context.MinObjectPixelSizeSq)
+                RenderTools::ComputeBoundsScreenRadiusSquared(sphere.Center, sphere.Radius, context.RenderContext.View) * context.ViewScreenSizeSq >= context.MinObjectPixelSizeSq) // TODO: technically, this should be using the main context
             {
                 if (!isMainContext)
                 {

--- a/Source/Engine/Graphics/RenderTools.cpp
+++ b/Source/Engine/Graphics/RenderTools.cpp
@@ -409,6 +409,13 @@ float RenderTools::ComputeBoundsScreenRadiusSquared(const Float3& origin, float 
     return Math::Square(screenMultiple * radius) / Math::Max(1.0f, distSqr);
 }
 
+float RenderTools::ComputeBoundsScreenRadiusSquared(float distanceSquared, float radius, const Matrix& projectionMatrix)
+{
+    const float screenMultiple = 0.5f * Math::Max(projectionMatrix.Values[0][0], projectionMatrix.Values[1][1]);
+    distanceSquared *= projectionMatrix.Values[2][3];
+    return Math::Square(screenMultiple * radius) / Math::Max(1.0f, distanceSquared);
+}
+
 int32 RenderTools::ComputeModelLOD(const Model* model, const Float3& origin, float radius, const RenderContext& renderContext)
 {
     const auto lodView = (renderContext.LodProxyView ? renderContext.LodProxyView : &renderContext.View);

--- a/Source/Engine/Graphics/RenderTools.h
+++ b/Source/Engine/Graphics/RenderTools.h
@@ -85,6 +85,8 @@ public:
     /// <returns>The squared radius.</returns>
     static float ComputeBoundsScreenRadiusSquared(const Float3& origin, float radius, const Float3& viewOrigin, const Matrix& projectionMatrix);
 
+    static float ComputeBoundsScreenRadiusSquared(float distanceSquared, float radius, const Matrix& projectionMatrix);
+
     /// <summary>
     /// Computes the model LOD index to use during rendering.
     /// </summary>

--- a/Source/Engine/Renderer/RenderList.cpp
+++ b/Source/Engine/Renderer/RenderList.cpp
@@ -656,6 +656,25 @@ void RenderList::AddDrawCall(const RenderContext& renderContext, DrawPass drawMo
     }
 }
 
+static bool CustomCullingCriteria(StaticFlags staticFlags, const RenderView& view, const BoundingSphere& bounds, float cullingDistanceSq, float minObjectPixelSizeSq)
+{
+    float distSq = Float3::DistanceSquared(view.Position, bounds.Center);
+    if ((staticFlags & StaticFlags::Occluder) == StaticFlags::None)
+    {
+        // non-occluders should just get culled after a certain distance
+        return (distSq < cullingDistanceSq);
+    }
+    else
+    {
+        if (distSq < cullingDistanceSq)
+        { // only do the minPixel check if the object is far away
+            return true;
+        }
+
+        return RenderTools::ComputeBoundsScreenRadiusSquared(bounds.Center, bounds.Radius, view) * (view.ScreenSize.X * view.ScreenSize.Y) >= minObjectPixelSizeSq;
+    }
+}
+
 void RenderList::AddDrawCall(const RenderContextBatch& renderContextBatch, DrawPass drawModes, StaticFlags staticFlags, ShadowsCastingMode shadowsMode, const BoundingSphere& bounds, DrawCall& drawCall, bool receivesDecals, int8 sortOrder)
 {
 #if ENABLE_ASSERTION_LOW_LAYERS
@@ -706,6 +725,8 @@ void RenderList::AddDrawCall(const RenderContextBatch& renderContextBatch, DrawP
         }
     }
     float minObjectPixelSizeSq = Math::Square(Graphics::Shadows::MinObjectPixelSize);
+    float cullingDistanceSq = Math::Square(Graphics::Shadows::CullingDistance);
+
     for (int32 i = 1; i < renderContextBatch.Contexts.Count(); i++)
     {
         const RenderContext& renderContext = renderContextBatch.Contexts.Get()[i];
@@ -714,9 +735,9 @@ void RenderList::AddDrawCall(const RenderContextBatch& renderContextBatch, DrawP
         // TODO: DSM frustum culling is broken - skip for now
         const bool frustumCheck = true; // renderContext.View.CullingFrustum.Intersects(bounds);
         if (drawModes != DrawPass::None &&
-            (staticFlags & renderContext.View.StaticFlagsMask) == renderContext.View.StaticFlagsCompare &&
-            frustumCheck &&
-            RenderTools::ComputeBoundsScreenRadiusSquared(bounds.Center, bounds.Radius, renderContext.View) * (renderContext.View.ScreenSize.X * renderContext.View.ScreenSize.Y) >= minObjectPixelSizeSq)
+            renderContext.View.CullingFrustum.Intersects(bounds) &&
+            (staticFlags & renderContext.View.StaticFlagsMask) == renderContext.View.StaticFlagsCompare
+            && CustomCullingCriteria(staticFlags, mainRenderContext.View, bounds, cullingDistanceSq, minObjectPixelSizeSq))
         {
             renderContext.List->ShadowDepthDrawCallsList.Indices.Add(index);
         }

--- a/Source/Engine/Renderer/RenderList.h
+++ b/Source/Engine/Renderer/RenderList.h
@@ -333,6 +333,7 @@ API_CLASS(Sealed) class FLAXENGINE_API RenderList : public ScriptingObject
     /// </summary>
     /// <param name="cache">The cache.</param>
     API_FUNCTION() static void ReturnToPool(RenderList* cache);
+public: static String DBG;
 
     /// <summary>
     /// Cleanups the static data cache used to accelerate draw calls sorting. Use it to reduce memory pressure.


### PR DESCRIPTION
There was an issue with the min pixel size culling for shadows. This fixes that, but also lowers FPS a little bit since it was actually culling too much stuff before.

I also made it so everything not with the Occluder static flag has their shadows culled now after a certain distance, defined by `Graphics.Shadows.CullingDistance`. Make sure world objects and large things (ships) have the occluder tag. The occluder tag currently doesn't do anything else (HZB doesnt use it anymore). The name is a bit of a misnomer.
