### PR TITLE
fix prefab sync cascade: stack overflow, cyclic parents, stale ID map…

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -191,8 +191,13 @@ void AnimatedModel::PreInitSkinningData()
     }
     _skinningData.OnDataChanged(true);
 
-    UpdateBounds();
-    UpdateSockets();
+    // Skip world-space operations when not in a scene (e.g. during prefab sync where the parent
+    // hierarchy may be incomplete/cyclic). Bounds will be updated properly in BeginPlay.
+    if (GetScene() || !_parent)
+    {
+        UpdateBounds();
+        UpdateSockets();
+    }
 }
 
 void AnimatedModel::GetCurrentPose(Array<Matrix>& nodesTransformation, bool worldSpace) const

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -317,6 +317,7 @@ bool PrefabInstanceData::SynchronizePrefabInstances(PrefabInstancesData& prefabI
         if (!newTargetActor)
         {
             LOG(Error, "Missing root object {0} for prefab instance {1}", defaultInstance->ToString(), oldTargetActor->ToString());
+            continue;
         }
         else if (oldTargetActor != newTargetActor)
         {
@@ -392,7 +393,9 @@ bool PrefabInstanceData::SynchronizePrefabInstances(PrefabInstancesData& prefabI
                 const ISerializable::DeserializeStream* data;
                 if (prefabObjectIdToDiffData.TryGet(obj->GetPrefabObjectID(), data))
                 {
-                    // Apply prefab changes
+                    // Apply prefab changes (scope guard prevents per-instance mapping entries
+                    // from leaking between iterations)
+                    ISerializeModifier::IdsMappingScope guard(*modifier.Value);
                     context.SetupIdsMapping(obj, modifier.Value);
                     obj->Deserialize(*(ISerializable::DeserializeStream*)data, modifier.Value);
                 }
@@ -426,6 +429,21 @@ bool PrefabInstanceData::SynchronizePrefabInstances(PrefabInstancesData& prefabI
 
         ObjectsRemovalService::Flush();
 
+        // Rebuild IdsMapping after removals to exclude stale entries from deleted objects
+        modifier.Value->IdsMapping.Clear();
+        for (int32 i = 0; i < sceneObjects->Count(); i++)
+        {
+            SceneObject* obj = sceneObjects.Value->At(i);
+            if (obj && obj->HasPrefabLink())
+                modifier.Value->IdsMapping[obj->GetPrefabObjectID()] = obj->GetSceneObjectId();
+        }
+        for (int32 i = 0; i < newPrefabObjectIds.Count(); i++)
+        {
+            if (modifier.Value->IdsMapping.ContainsKey(newPrefabObjectIds[i]))
+                continue;
+            modifier->IdsMapping[newPrefabObjectIds[i]] = Guid::New();
+        }
+
         // Restore local changes (for the existing scene objects)
         for (int32 i = 0; i < sceneObjects->Count(); i++)
         {
@@ -445,6 +463,7 @@ bool PrefabInstanceData::SynchronizePrefabInstances(PrefabInstancesData& prefabI
                 data.RemoveMember("ParentID");
 #endif
 
+                ISerializeModifier::IdsMappingScope guard(*modifier.Value);
                 context.SetupIdsMapping(obj, modifier.Value);
                 obj->Deserialize(data, modifier.Value);
 
@@ -1040,6 +1059,9 @@ bool Prefab::ApplyAllInternal(Actor* targetActor, bool linkTargetActorObjectToPr
             SceneObject* obj = sceneObjects->At(i);
             if (!obj)
                 continue;
+            // Scope guard prevents stale entries from one nested prefab instance's
+            // mapping affecting another instance's ParentID resolution
+            ISerializeModifier::IdsMappingScope guard(*modifier.Value);
             SceneObjectsFactory::Deserialize(context, obj, data[i]);
 
             int32 dataIndex;
@@ -1381,34 +1403,46 @@ bool Prefab::SyncChangesInternal(PrefabInstancesData& prefabInstancesData)
     return ApplyAllInternal(targetActor, false, prefabInstancesData);
 }
 
-void Prefab::SyncNestedPrefabs(const NestedPrefabsList& allPrefabs, Array<PrefabInstancesData>& allPrefabsInstancesData) const
+void Prefab::SyncNestedPrefabs(const NestedPrefabsList& allPrefabs, Array<PrefabInstancesData>& allPrefabsInstancesData, HashSet<Guid>* syncedIds) const
 {
     PROFILE_CPU();
     LOG(Info, "Updating referencing prefabs");
 
-    // TODO: this may not work well for very complex prefab nesting -> loop order matters, maybe build a graph of dependencies?
+    // Track which prefabs have already been synced to prevent double-syncing
+    // through different cascade paths (e.g., A nests B and C, both nest D — D should only sync once)
+    HashSet<Guid> localSyncedIds;
+    if (!syncedIds)
+    {
+        syncedIds = &localSyncedIds;
+        syncedIds->Add(GetID());
+    }
 
     // Call recursive for all referencing prefab assets to refresh nested prefabs
     for (int32 i = 0; i < allPrefabs.Count(); i++)
     {
         auto nestedPrefab = allPrefabs[i].Get();
-        if (nestedPrefab)
-        {
-            if (nestedPrefab->WaitForLoaded())
-            {
-                LOG(Warning, "Waiting for prefab asset load failed.");
-                continue;
-            }
+        if (!nestedPrefab)
+            continue;
 
-            // Sync only if prefab is used by this prefab (directly) and it has been captured before
-            const int32 nestedPrefabIndex = nestedPrefab->NestedPrefabs.Find(GetID());
-            if (nestedPrefabIndex != -1)
-            {
-                if (nestedPrefab->SyncChangesInternal(allPrefabsInstancesData[i]))
-                    continue;
-                nestedPrefab->SyncNestedPrefabs(allPrefabs, allPrefabsInstancesData);
-                ObjectsRemovalService::Flush();
-            }
+        // Skip already-synced prefabs
+        if (syncedIds->Contains(nestedPrefab->GetID()))
+            continue;
+
+        if (nestedPrefab->WaitForLoaded())
+        {
+            LOG(Warning, "Waiting for prefab asset load failed.");
+            continue;
+        }
+
+        // Sync only if prefab is used by this prefab (directly) and it has been captured before
+        const int32 nestedPrefabIndex = nestedPrefab->NestedPrefabs.Find(GetID());
+        if (nestedPrefabIndex != -1)
+        {
+            syncedIds->Add(nestedPrefab->GetID());
+            if (nestedPrefab->SyncChangesInternal(allPrefabsInstancesData[i]))
+                continue;
+            nestedPrefab->SyncNestedPrefabs(allPrefabs, allPrefabsInstancesData, syncedIds);
+            ObjectsRemovalService::Flush();
         }
     }
 }

--- a/Source/Engine/Level/Prefabs/Prefab.h
+++ b/Source/Engine/Level/Prefabs/Prefab.h
@@ -5,6 +5,7 @@
 #include "Engine/Content/JsonAsset.h"
 #include "Engine/Core/Collections/Array.h"
 #include "Engine/Core/Collections/Dictionary.h"
+#include "Engine/Core/Collections/HashSet.h"
 
 class Actor;
 class SceneObject;
@@ -102,7 +103,7 @@ private:
     bool ApplyAllInternal(Actor* targetActor, bool linkTargetActorObjectToPrefab, PrefabInstancesData& prefabInstancesData);
     bool UpdateInternal(const Array<SceneObject*>& defaultInstanceObjects, rapidjson_flax::StringBuffer& tmpBuffer);
     bool SyncChangesInternal(PrefabInstancesData& prefabInstancesData);
-    void SyncNestedPrefabs(const NestedPrefabsList& allPrefabs, Array<PrefabInstancesData>& allPrefabsInstancesData) const;
+    void SyncNestedPrefabs(const NestedPrefabsList& allPrefabs, Array<PrefabInstancesData>& allPrefabsInstancesData, HashSet<Guid>* syncedIds = nullptr) const;
 #endif
     void DeleteDefaultInstance();
 

--- a/Source/Engine/Serialization/ISerializeModifier.h
+++ b/Source/Engine/Serialization/ISerializeModifier.h
@@ -35,16 +35,19 @@ public:
     {
         ISerializeModifier& Modifier;
         Dictionary<Guid, Guid> Saved;
+        int32 SavedInstance;
 
         IdsMappingScope(ISerializeModifier& modifier)
             : Modifier(modifier)
             , Saved(modifier.IdsMapping)
+            , SavedInstance(modifier.CurrentInstance)
         {
         }
 
         ~IdsMappingScope()
         {
             Modifier.IdsMapping = Saved;
+            Modifier.CurrentInstance = SavedInstance;
         }
 
         NON_COPYABLE(IdsMappingScope);

--- a/Source/Engine/Serialization/ISerializeModifier.h
+++ b/Source/Engine/Serialization/ISerializeModifier.h
@@ -25,4 +25,28 @@ public:
     /// The object IDs mapping. Key is a serialized object id, value is mapped value to use.
     /// </summary>
     Dictionary<Guid, Guid> IdsMapping;
+
+    /// <summary>
+    /// RAII guard that snapshots IdsMapping on construction and restores it on destruction.
+    /// Prevents per-instance mapping entries from leaking between nested prefab instances
+    /// during recursive sync/deserialization.
+    /// </summary>
+    struct IdsMappingScope
+    {
+        ISerializeModifier& Modifier;
+        Dictionary<Guid, Guid> Saved;
+
+        IdsMappingScope(ISerializeModifier& modifier)
+            : Modifier(modifier)
+            , Saved(modifier.IdsMapping)
+        {
+        }
+
+        ~IdsMappingScope()
+        {
+            Modifier.IdsMapping = Saved;
+        }
+
+        NON_COPYABLE(IdsMappingScope);
+    };
 };


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                                                 
  Fixes a crash (stack overflow) when saving changes to a nested prefab. Stale ID mappings leak between prefab instances during sync, causing cyclic parent chains. When an AnimatedModel triggers `UpdateBounds`
   during sync, the cyclic hierarchy recurses infinitely.                                                                                                                                                      

  Three layers of fix:
  - **RAII guard** isolates IdsMapping per prefab instance so entries don't leak between iterations
  - **Visited-set** in `SyncNestedPrefabs` prevents double-processing in diamond dependencies
  - **Skip world-space ops during sync** — `UpdateBounds`/`UpdateSockets` deferred when parent hierarchy is incomplete

  ## Repro case

  Project: `bug_prefabsynccascade`

  1. Open `Content/InnerPrefab`
  2. Duplicate `3rd_rig` and drag it under `static model 0`
  3. Save
  4. **Expected (before fix):** Editor crashes (stack overflow)
  5. **Expected (after fix):** Save completes normally

  > Note: the bug requires 2+ skinned models in the inner prefab to trigger the crash.