### PR TITLE
fix asset cache eviction for locked files and reload race condition

### DIFF
--- a/Source/Engine/Content/Asset.cpp
+++ b/Source/Engine/Content/Asset.cpp
@@ -427,6 +427,9 @@ void Asset::Reload()
 
         ScopeLock lock(Locker);
 
+        // Cancel any still-running loading task (e.g. if WaitForLoaded timed out)
+        Platform::AtomicStore(&_loadingTask, 0);
+
         if (IsLoaded())
         {
             // Unload current data
@@ -599,14 +602,34 @@ bool Asset::IsInternalType() const
     return false;
 }
 
+// Check if 'task' is reachable from the head of the loading task chain (BinaryAsset chains InitAssetTask -> LoadAssetDataTask -> LoadAssetTask).
+static bool IsTaskInLoadingChain(volatile intptr& loadingTask, Task* task)
+{
+    auto head = (Task*)Platform::AtomicRead(&loadingTask);
+    while (head)
+    {
+        if (head == task)
+            return true;
+        head = head->GetContinueWithTask();
+    }
+    return false;
+}
+
 bool Asset::onLoad(LoadAssetTask* task)
 {
     // It may fail when task is cancelled and new one was created later (don't crash but just end with an error)
-    if (task->Asset.Get() != this || Platform::AtomicRead(&_loadingTask) == 0)
+    if (task->Asset.Get() != this || !IsTaskInLoadingChain(_loadingTask, task))
         return true;
     LogContextScope logContext(GetID());
 
     Locker.Lock();
+
+    // Re-check after acquiring lock (loading task may have been cleared by Reload, or replaced by a new task)
+    if (!IsTaskInLoadingChain(_loadingTask, task))
+    {
+        Locker.Unlock();
+        return true;
+    }
 
     // Load asset
     LoadResult result;

--- a/Source/Engine/Content/Cache/AssetsCache.cpp
+++ b/Source/Engine/Content/Cache/AssetsCache.cpp
@@ -112,8 +112,9 @@ void AssetsCache::Init()
             e.Info.Path = Globals::StartupFolder / e.Info.Path;
         }
 
-        // Use only valid entries
-        if (IsEntryValid(e))
+        // Use only valid entries (keep inaccessible entries so they can be retried later)
+        const auto validation = IsEntryValid(e);
+        if (validation != EntryValidation::Invalid)
             _registry.Add(e.Info.ID, e);
         else
             rejectedCount++;
@@ -295,14 +296,20 @@ bool AssetsCache::FindAsset(const StringView& path, AssetInfo& info)
         auto& e = i->Value;
         if (e.Info.Path == path)
         {
-            if (!IsEntryValid(e))
+            const auto validation = IsEntryValid(e);
+            if (validation == EntryValidation::Invalid)
             {
                 LOG(Warning, "Missing file from registry: \'{0}\':{1}:{2}", e.Info.Path, e.Info.ID, e.Info.TypeName);
                 _registry.Remove(i);
             }
             else
             {
-                // Found
+                if (validation == EntryValidation::Inaccessible && !e.WarnedInaccessible)
+                {
+                    LOG(Warning, "Asset file locked, keeping cached entry: \'{0}\':{1}:{2}", e.Info.Path, e.Info.ID, e.Info.TypeName);
+                    e.WarnedInaccessible = true;
+                }
+                // Found (valid or inaccessible — return cached info either way)
                 result = true;
                 info = e.Info;
             }
@@ -322,13 +329,19 @@ bool AssetsCache::FindAsset(const Guid& id, AssetInfo& info)
     auto e = _registry.TryGet(id);
     if (e != nullptr)
     {
-        if (!IsEntryValid(*e))
+        const auto validation = IsEntryValid(*e);
+        if (validation == EntryValidation::Invalid)
         {
             LOG(Warning, "Missing file from registry: \'{0}\':{1}:{2}", e->Info.Path, e->Info.ID, e->Info.TypeName);
             _registry.Remove(id);
         }
         else
         {
+            if (validation == EntryValidation::Inaccessible && !e->WarnedInaccessible)
+            {
+                LOG(Warning, "Asset file locked, keeping cached entry: \'{0}\':{1}:{2}", e->Info.Path, e->Info.ID, e->Info.TypeName);
+                e->WarnedInaccessible = true;
+            }
             // Found
             result = true;
             info = e->Info;
@@ -569,60 +582,71 @@ bool AssetsCache::RenameAsset(const StringView& oldPath, const StringView& newPa
 
 #endif
 
-bool AssetsCache::IsEntryValid(Entry& e)
+EntryValidation AssetsCache::IsEntryValid(Entry& e)
 {
 #if ENABLE_ASSETS_DISCOVERY
     // Check if file exists
-    if (FileSystem::FileExists(e.Info.Path))
+    if (!FileSystem::FileExists(e.Info.Path))
+        return EntryValidation::Invalid;
+
+    // Check if file hasn't been modified
+    const auto fileModified = FileSystem::GetFileLastEditTime(e.Info.Path);
+    if (fileModified == e.FileModified)
     {
-        // Check if file hasn't been modified
-        const auto fileModified = FileSystem::GetFileLastEditTime(e.Info.Path);
-        if (fileModified == e.FileModified)
-            return true;
-
-        const auto extension = FileSystem::GetExtension(e.Info.Path).ToLower();
-
-        // Check if it's a binary asset
-        if (ContentStorageManager::IsFlaxStorageExtension(extension))
-        {
-            // Validate ID within storage container
-            const auto storage = ContentStorageManager::GetStorage(e.Info.Path);
-            if (storage)
-            {
-                // Check if storage at given location contains that asset
-                const bool isValid = storage->HasAsset(e.Info);
-
-                // Update entry and mark cache as dirty
-                e.FileModified = fileModified;
-                _isDirty = true;
-
-                return isValid;
-            }
-        }
-        // Check for json resource
-        else if (JsonStorageProxy::IsValidExtension(extension))
-        {
-            // Check Json storage layer
-            Guid jsonId;
-            String jsonTypeName;
-            if (JsonStorageProxy::GetAssetInfo(e.Info.Path, jsonId, jsonTypeName))
-            {
-                const bool isValid = e.Info.ID == jsonId && e.Info.TypeName == jsonTypeName;
-
-                // Update entry and mark cache as dirty
-                e.FileModified = fileModified;
-                _isDirty = true;
-
-                return isValid;
-            }
-        }
+        e.WarnedInaccessible = false;
+        return EntryValidation::Valid;
     }
 
-    return false;
+    const auto extension = FileSystem::GetExtension(e.Info.Path).ToLower();
+
+    // Check if it's a binary asset
+    if (ContentStorageManager::IsFlaxStorageExtension(extension))
+    {
+        // Validate ID within storage container
+        const auto storage = ContentStorageManager::GetStorage(e.Info.Path);
+        if (storage)
+        {
+            // Check if storage at given location contains that asset
+            const bool isValid = storage->HasAsset(e.Info);
+
+            // Update entry and mark cache as dirty
+            e.FileModified = fileModified;
+            e.WarnedInaccessible = false;
+            _isDirty = true;
+
+            return isValid ? EntryValidation::Valid : EntryValidation::Invalid;
+        }
+
+        // File exists but cannot be opened (likely locked by git or another process)
+        return EntryValidation::Inaccessible;
+    }
+    // Check for json resource
+    else if (JsonStorageProxy::IsValidExtension(extension))
+    {
+        // Check Json storage layer
+        Guid jsonId;
+        String jsonTypeName;
+        if (JsonStorageProxy::GetAssetInfo(e.Info.Path, jsonId, jsonTypeName))
+        {
+            const bool isValid = e.Info.ID == jsonId && e.Info.TypeName == jsonTypeName;
+
+            // Update entry and mark cache as dirty
+            e.FileModified = fileModified;
+            e.WarnedInaccessible = false;
+            _isDirty = true;
+
+            return isValid ? EntryValidation::Valid : EntryValidation::Invalid;
+        }
+
+        // File exists but cannot be read (likely locked by git or another process)
+        return EntryValidation::Inaccessible;
+    }
+
+    return EntryValidation::Invalid;
 
 #else
     // In game we don't care about it because all cached asset entries are valid (precached)
     // Skip only entries with missing file
-    return e.Info.Path.HasChars();
+    return e.Info.Path.HasChars() ? EntryValidation::Valid : EntryValidation::Invalid;
 #endif
 }

--- a/Source/Engine/Content/Cache/AssetsCache.h
+++ b/Source/Engine/Content/Cache/AssetsCache.h
@@ -38,6 +38,27 @@ enum class AssetsCacheFlags : int32
 DECLARE_ENUM_OPERATORS(AssetsCacheFlags);
 
 /// <summary>
+/// Result of validating an asset cache entry.
+/// </summary>
+enum class EntryValidation
+{
+    /// <summary>
+    /// File verified, contains this asset.
+    /// </summary>
+    Valid,
+
+    /// <summary>
+    /// File missing or contains a different asset.
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// File exists but cannot be opened (locked by another process).
+    /// </summary>
+    Inaccessible,
+};
+
+/// <summary>
 /// Flax Game Engine assets cache container
 /// </summary>
 class FLAXENGINE_API AssetsCache
@@ -60,6 +81,11 @@ public:
         DateTime FileModified;
 #endif
 
+        /// <summary>
+        /// True if a warning about this entry being inaccessible has already been logged (prevents log spam). Runtime-only, not serialized.
+        /// </summary>
+        bool WarnedInaccessible = false;
+
         Entry()
         {
         }
@@ -69,6 +95,7 @@ public:
 #if ENABLE_ASSETS_DISCOVERY
             , FileModified(DateTime::NowUTC())
 #endif
+            , WarnedInaccessible(false)
         {
         }
     };
@@ -232,6 +259,6 @@ public:
     /// Determines whether cached asset entry is valid.
     /// </summary>
     /// <param name="e">The asset entry.</param>
-    /// <returns>True if is valid, otherwise false.</returns>
-    bool IsEntryValid(Entry& e);
+    /// <returns>The validation result.</returns>
+    EntryValidation IsEntryValid(Entry& e);
 };


### PR DESCRIPTION
  ## Summary                                                                                                                                  
                                                                                                                                              
  - **Asset cache** no longer evicts entries when a file exists but can't be opened (e.g., locked by git or antivirus). New three-state       
  validation (Valid/Invalid/Inaccessible) keeps locked entries with a one-time warning instead of silently dropping them.                   
  - **Asset reload** clears the in-flight loading task on reload, and `onLoad` now walks the task continuation chain to verify task identity.
  Prevents stale loading tasks from overwriting freshly reloaded data or orphaning new tasks.

  ## Repro case — cache eviction (permanent reference loss)

  Project: `bug_assetsystemrobustness`

First run the project with standard derelict-mods, and check that the script on TEST, references the model. Close the editor. 

  1. Run `powershell -File lock_mesh.ps1` 
  2. Start the editor while the lock is held
  3. The C# `Model` reference on the "TEST" actor is set to null, GUID is lost
  6. Save the scene
  7. Release the lock (Ctrl+C), restart the editor, 

Reference to the mesh is broken permanently 

[bug_assetsystemrobustness.zip](https://github.com/user-attachments/files/26342565/bug_assetsystemrobustness.zip)