### PR TITLE
fix silent material fallback and cleared GUID overrides not surviving…

### DIFF
--- a/Source/Engine/Content/Asset.cpp
+++ b/Source/Engine/Content/Asset.cpp
@@ -88,6 +88,7 @@ void AssetReferenceBase::OnSet(Asset* asset)
         if (e)
             e->RemoveReference(this);
         _asset = e = asset;
+        _id = e ? e->GetID() : Guid::Empty;
         if (e)
             e->AddReference(this);
         Changed();

--- a/Source/Engine/Content/AssetReference.h
+++ b/Source/Engine/Content/AssetReference.h
@@ -12,6 +12,10 @@ class FLAXENGINE_API AssetReferenceBase : public IAssetReference
 protected:
     Asset* _asset = nullptr;
     IAssetReference* _owner = nullptr;
+    // Cached separately from _asset so that GetID() returns the assigned ID even before the
+    // asset finishes loading. Without this, code that checks GetID() == Guid::Empty to mean
+    // "no asset was assigned" would get false positives while the asset is still loading.
+    Guid _id = Guid::Empty;
 
 public:
     /// <summary>
@@ -50,11 +54,12 @@ public:
 
 public:
     /// <summary>
-    /// Gets the asset ID or Guid::Empty if not set.
+    /// Gets the asset ID or Guid::Empty if not set. Returns the assigned ID immediately,
+    /// even if the asset hasn't finished loading yet.
     /// </summary>
     FORCE_INLINE Guid GetID() const
     {
-        return _asset ? _asset->GetID() : Guid::Empty;
+        return _id;
     }
 
     /// <summary>
@@ -170,6 +175,7 @@ public:
 
     FORCE_INLINE AssetReference& operator=(const Guid& id)
     {
+        _id = id;
         OnSet(::LoadAsset(id, T::TypeInitializer));
         return *this;
     }

--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -1329,7 +1329,7 @@ MaterialBase* AnimatedModel::GetMaterial(int32 entryIndex)
         return nullptr;
     CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
     MaterialBase* material = Entries[entryIndex].Material.Get();
-    if (!material)
+    if (!material && Entries[entryIndex].Material.GetID() == Guid::Empty)
     {
         material = SkinnedModel->MaterialSlots[entryIndex].Material.Get();
         if (!material)

--- a/Source/Engine/Level/Actors/SplineModel.cpp
+++ b/Source/Engine/Level/Actors/SplineModel.cpp
@@ -358,7 +358,7 @@ MaterialBase* SplineModel::GetMaterial(int32 entryIndex)
         return nullptr;
     CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
     MaterialBase* material = Entries[entryIndex].Material.Get();
-    if (!material)
+    if (!material && Entries[entryIndex].Material.GetID() == Guid::Empty)
     {
         material = Model->MaterialSlots[entryIndex].Material.Get();
         if (!material)

--- a/Source/Engine/Level/Actors/StaticModel.cpp
+++ b/Source/Engine/Level/Actors/StaticModel.cpp
@@ -115,7 +115,9 @@ MaterialBase* StaticModel::GetMaterial(int32 meshIndex, int32 lodIndex) const
     const auto& mesh = model->LODs[lodIndex].Meshes[meshIndex];
     const auto materialSlotIndex = mesh.GetMaterialSlotIndex();
     MaterialBase* material = Entries[materialSlotIndex].Material.Get();
-    return material ? material : model->MaterialSlots[materialSlotIndex].Material.Get();
+    if (!material && Entries[materialSlotIndex].Material.GetID() == Guid::Empty)
+        material = model->MaterialSlots[materialSlotIndex].Material.Get();
+    return material;
 }
 
 Color32 StaticModel::GetVertexColor(int32 lodIndex, int32 meshIndex, int32 vertexIndex) const
@@ -582,8 +584,10 @@ MaterialBase* StaticModel::GetMaterial(int32 entryIndex)
         return nullptr;
     CHECK_RETURN(entryIndex >= 0 && entryIndex < Entries.Count(), nullptr);
     MaterialBase* material = Entries[entryIndex].Material.Get();
-    if (!material && entryIndex < Model->MaterialSlots.Count())
+    if (!material && Entries[entryIndex].Material.GetID() == Guid::Empty && entryIndex < Model->MaterialSlots.Count())
     {
+        // Only fall back to model default when no material was explicitly assigned.
+        // If a material was assigned but is missing, don't mask the problem with a fallback.
         material = Model->MaterialSlots[entryIndex].Material.Get();
         if (!material)
             material = GPUDevice::Instance->GetDefaultMaterial();

--- a/Source/Engine/Serialization/Serialization.cpp
+++ b/Source/Engine/Serialization/Serialization.cpp
@@ -401,7 +401,12 @@ void Serialization::Deserialize(ISerializable::DeserializeStream& stream, Varian
 
 bool Serialization::ShouldSerialize(const Guid& v, const void* otherObj)
 {
-    return v.IsValid();
+    // Compare against default rather than just checking IsValid(), so that an
+    // Empty Guid override on a prefab instance is correctly serialized as a diff.
+    // Without this, clearing a Guid field on an instance silently reverts on reload.
+    if (!otherObj)
+        return true;
+    return v != *(Guid*)otherObj;
 }
 
 void Serialization::Serialize(ISerializable::SerializeStream& stream, const Guid& v, const void* otherObj)


### PR DESCRIPTION
  ## Summary                                                                                                                                                             

This one is subtle, but it's caused me hours of headaches. TLDR; if you delete a material, it will revert it to a known default, rather than letting me know what broke so i can go fix it properly, so you end up with meshes that look correct, but actually have the wrong materials. 
                                                                                                                                                                         
  - **Material fallback** on StaticModel, AnimatedModel, and SplineModel now only triggers when no material was ever assigned. If a material was assigned but is
  missing/broken, the slot renders with no material instead of silently substituting the mesh default — making the broken state visible so it can be found and fixed.
  - **AssetReference** caches the assigned asset ID immediately on assignment, so references are distinguishable from "never assigned" even during async load.
  - **ShouldSerialize(Guid)** compares against the prefab default instead of checking IsValid, so intentionally cleared references persist through save/load.

  ## Repro case

  Project: `bug_materialfallback`

  1. Open the scene — `cockpit_basic` has a material reference pointing at a deleted asset
  2. **Before fix:** Mesh renders with its default material — broken reference is invisible, error is hidden
  3. **After fix:** Slot renders pink (no material), log identifies the broken reference:
     `Missing asset of type FlaxEngine.MaterialBase (ID=...) in actor 'Scene/test/cockpit_basic'`