### PR TITLE
validate GUID hex parsing and handle missing scripts without crashing

### DIFF
--- a/Source/Engine/Serialization/Serialization.cpp
+++ b/Source/Engine/Serialization/Serialization.cpp
@@ -420,10 +420,17 @@ void Serialization::Deserialize(ISerializable::DeserializeStream& stream, Guid& 
     const char* b = a + 8;
     const char* c = b + 8;
     const char* d = c + 8;
-    StringUtils::ParseHex(a, 8, &v.A);
-    StringUtils::ParseHex(b, 8, &v.B);
-    StringUtils::ParseHex(c, 8, &v.C);
-    StringUtils::ParseHex(d, 8, &v.D);
+    // Validate hex parsing to catch corrupted data (e.g. from git merge conflicts).
+    // JsonTools::GetGuid already does this check; this path did not.
+    bool failed = StringUtils::ParseHex(a, 8, &v.A);
+    failed |= StringUtils::ParseHex(b, 8, &v.B);
+    failed |= StringUtils::ParseHex(c, 8, &v.C);
+    failed |= StringUtils::ParseHex(d, 8, &v.D);
+    if (failed)
+    {
+        LOG(Warning, "Failed to parse Guid from string during deserialization.");
+        v = Guid::Empty;
+    }
 }
 
 bool Serialization::ShouldSerialize(const DateTime& v, const void* otherObj)

--- a/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
+++ b/Source/Tools/Flax.Build/Bindings/BindingsGenerator.Cpp.cs
@@ -1466,6 +1466,22 @@ namespace Flax.Build.Bindings
             contents.Append(indent).AppendLine("return __return;");
         }
 
+        private static void GenerateCppManagedNullGuard(BuildData buildData, StringBuilder contents, string condition, string message, string indent, FunctionInfo functionInfo, string cleanup = null)
+        {
+            contents.AppendLine($"{indent}if ({condition})");
+            contents.AppendLine($"{indent}{{");
+            if (cleanup != null)
+                contents.AppendLine($"{indent}    {cleanup}");
+            contents.AppendLine($"{indent}    static bool logged = false;");
+            contents.AppendLine($"{indent}    if (!logged)");
+            contents.AppendLine($"{indent}    {{");
+            contents.AppendLine($"{indent}        logged = true;");
+            contents.AppendLine($"{indent}        LOG(Warning, \"{message}\", String(managedTypePtr->Fullname), object->ToString(), object->GetID());");
+            contents.AppendLine($"{indent}    }}");
+            GenerateCppReturn(buildData, contents, $"{indent}    ", functionInfo.ReturnType);
+            contents.AppendLine($"{indent}}}");
+        }
+
         private static void GenerateCppManagedWrapperFunction(BuildData buildData, StringBuilder contents, VirtualClassInfo classInfo, FunctionInfo functionInfo, int scriptVTableSize, int scriptVTableIndex)
         {
             if (!EngineConfiguration.WithCSharp(buildData.TargetOptions))
@@ -1524,12 +1540,21 @@ namespace Flax.Build.Bindings
             contents.AppendLine("        }");
 
             contents.AppendLine("        auto scriptVTable = (MMethod**)managedTypePtr->Script.ScriptVTable;");
-            contents.AppendLine($"        ASSERT(scriptVTable && scriptVTable[{scriptVTableOffset}]);");
+            GenerateCppManagedNullGuard(buildData, contents,
+                $"!scriptVTable || !scriptVTable[{scriptVTableOffset}]",
+                $"Missing managed virtual method '{{0}}::{functionInfo.Name}' on object '{{1}}' (id: {{2}}). Script type may be missing or failed to load.",
+                "        ", functionInfo);
             contents.AppendLine($"        auto method = scriptVTable[{scriptVTableOffset}];");
 
             contents.AppendLine("        MObject* exception = nullptr;");
             contents.AppendLine("        auto prevWrapperCallInstance = WrapperCallInstance;");
             contents.AppendLine("        WrapperCallInstance = object;");
+            contents.AppendLine("        auto managedInstance = object->GetOrCreateManagedInstance();");
+            GenerateCppManagedNullGuard(buildData, contents,
+                "!managedInstance",
+                $"Failed to create managed instance for '{{0}}::{functionInfo.Name}' on object '{{1}}' (id: {{2}}). Managed type may be missing or assembly failed to load.",
+                "        ", functionInfo,
+                "WrapperCallInstance = prevWrapperCallInstance;");
 
             if (functionInfo.Parameters.Count == 0)
                 contents.AppendLine("        void** params = nullptr;");
@@ -1581,13 +1606,13 @@ namespace Flax.Build.Bindings
                 {
                     contents.AppendLine($"        typedef void (*Thunk)(void* instance{thunkParams}, MObject** exception);");
                     contents.AppendLine("        const auto thunk = (Thunk)method->GetThunk();");
-                    contents.AppendLine($"        thunk(object->GetOrCreateManagedInstance(){thunkCall}, &exception);");
+                    contents.AppendLine($"        thunk(managedInstance{thunkCall}, &exception);");
                 }
                 else
                 {
                     contents.AppendLine($"        typedef MObject* (*Thunk)(void* instance{thunkParams}, MObject** exception);");
                     contents.AppendLine("        const auto thunk = (Thunk)method->GetThunk();");
-                    contents.AppendLine($"        MObject* __result = thunk(object->GetOrCreateManagedInstance(){thunkCall}, &exception);");
+                    contents.AppendLine($"        MObject* __result = thunk(managedInstance{thunkCall}, &exception);");
                 }
 
                 // Convert parameter values back from managed to native (could be modified there)
@@ -1617,7 +1642,7 @@ namespace Flax.Build.Bindings
                 }
 
                 // Invoke method
-                contents.AppendLine("        MObject* __result = method->Invoke(object->GetOrCreateManagedInstance(), params, &exception);");
+                contents.AppendLine("        MObject* __result = method->Invoke(managedInstance, params, &exception);");
 
                 // Convert parameter values back from managed to native (could be modified there)
                 for (var i = 0; i < functionInfo.Parameters.Count; i++)


### PR DESCRIPTION
This one is really just quality of life. If you ever broke a script, with the flax debugger attached you'd hit an assert, which is no good for a user level issue. So we just turn the assert to a warning.  

GUID deserialization now checks ParseHex return values and logs a warning on corrupted data instead of producing garbage values. 

