### PR TITLE
improve editor diagnostic logging and fix window layout location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ PackageEditor_Cert.bat
 PackagePlatforms_Cert.bat
 
 # User-specific files
+WindowsLayout.xml
 *.suo
 *.user
 *.sln.docstates

--- a/Source/Editor/Modules/WindowsModule.cs
+++ b/Source/Editor/Modules/WindowsModule.cs
@@ -757,7 +757,7 @@ namespace FlaxEditor.Modules
         {
             Assert.IsNull(MainWindow);
 
-            _windowsLayoutPath = StringUtils.CombinePaths(Globals.ProjectCacheFolder, "WindowsLayout.xml");
+            _windowsLayoutPath = StringUtils.CombinePaths(Globals.ProjectFolder, "WindowsLayout.xml");
 
             // Create main window
             var settings = CreateWindowSettings.Default;

--- a/Source/Engine/Content/Assets/MaterialBase.cpp
+++ b/Source/Engine/Content/Assets/MaterialBase.cpp
@@ -3,6 +3,7 @@
 #include "MaterialBase.h"
 #include "MaterialInstance.h"
 #include "Engine/Core/Log.h"
+#include "Engine/Core/LogContext.h"
 #include "Engine/Core/Types/Variant.h"
 #include "Engine/Content/Content.h"
 #include "Engine/Content/Factories/BinaryAssetFactory.h"
@@ -23,7 +24,9 @@ Variant MaterialBase::GetParameterValue(const StringView& name)
     {
         return param->GetValue();
     }
-    LOG(Warning, "Missing material parameter '{0}' in material {1}", String(name), ToString());
+    const String context = LogContext::FormatContext();
+    LOG(Warning, "Missing material parameter '{0}' in material {1}.{2}", String(name), ToString(), context);
+    LogContext::Print(LogType::Warning);
     return Variant::Null;
 }
 
@@ -39,7 +42,9 @@ void MaterialBase::SetParameterValue(const StringView& name, const Variant& valu
     }
     else if (warnIfMissing)
     {
-        LOG(Warning, "Missing material parameter '{0}' in material {1}", name, ToString());
+        const String context = LogContext::FormatContext();
+        LOG(Warning, "Missing material parameter '{0}' in material {1}.{2}", name, ToString(), context);
+        LogContext::Print(LogType::Warning);
     }
 }
 

--- a/Source/Engine/Level/Prefabs/Prefab.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.cpp
@@ -61,7 +61,7 @@ Actor* Prefab::GetDefaultInstance()
     // Skip if not loaded
     if (!IsLoaded())
     {
-        LOG(Warning, "Cannot instantiate object from not loaded prefab asset.");
+        LOG(Warning, "Cannot instantiate object from not loaded prefab asset. Prefab: {0} (ID: {1})", GetPath(), GetID());
         return nullptr;
     }
 

--- a/Source/Engine/Level/SceneObjectsFactory.cpp
+++ b/Source/Engine/Level/SceneObjectsFactory.cpp
@@ -165,7 +165,8 @@ SceneObject* SceneObjectsFactory::Spawn(Context& context, const ISerializable::D
         const ISerializable::DeserializeStream* prefabData;
         if (!prefab->ObjectsDataCache.TryGet(prefabObjectId, prefabData))
         {
-            LOG(Warning, "Missing object {1} data in prefab {0}.", prefab->ToString(), prefabObjectId);
+            const String context = LogContext::FormatContext();
+            LOG(Warning, "Missing object {1} data in prefab {0}.{2}", prefab->ToString(), prefabObjectId, context);
             return nullptr;
         }
 
@@ -291,7 +292,8 @@ void SceneObjectsFactory::Deserialize(Context& context, SceneObject* obj, ISeria
         const ISerializable::DeserializeStream* prefabData;
         if (!prefab->ObjectsDataCache.TryGet(prefabObjectId, prefabData))
         {
-            LOG(Warning, "Missing object {1} data in prefab {0}.", prefab->ToString(), prefabObjectId);
+            const String context = LogContext::FormatContext();
+            LOG(Warning, "Missing object {1} data in prefab {0}.{2}", prefab->ToString(), prefabObjectId, context);
             return;
         }
 
@@ -593,7 +595,8 @@ void SceneObjectsFactory::SynchronizeNewPrefabInstances(Context& context, Prefab
                 const ISerializable::DeserializeStream* prefabData;
                 if (!instance.Prefab->ObjectsDataCache.TryGet(prefabRootId, prefabData))
                 {
-                    LOG(Warning, "Missing object {1} data in prefab {0}.", instance.Prefab->ToString(), prefabObjectId);
+                    const String context = LogContext::FormatContext();
+                    LOG(Warning, "Missing object {1} data in prefab {0}.{2}", instance.Prefab->ToString(), prefabObjectId, context);
                     continue;
                 }
 
@@ -861,7 +864,8 @@ void SceneObjectsFactory::SynchronizeNewPrefabInstance(Context& context, PrefabS
     const ISerializable::DeserializeStream* prefabData;
     if (!prefab->ObjectsDataCache.TryGet(prefabObjectId, prefabData))
     {
-        LOG(Warning, "Missing object {1} data in prefab {0}.", prefab->ToString(), prefabObjectId);
+        const String context = LogContext::FormatContext();
+        LOG(Warning, "Missing object {1} data in prefab {0}.{2}", prefab->ToString(), prefabObjectId, context);
         return;
     }
 


### PR DESCRIPTION
Another simple small one, this just means we don't nuke the editor config when we clear cache, and improved some logging, so it's easier to fix things. 

Add full context chain (scene, prefab, actor) to material and prefab warnings. 

Move WindowsLayout.xml out of cache folder so layout survives cache clears, added to .gitignore.