### PR TITLE
add reset and relink actions for broken prefab instances

### DIFF
--- a/Source/Editor/Modules/PrefabsModule.cs
+++ b/Source/Editor/Modules/PrefabsModule.cs
@@ -234,6 +234,60 @@ namespace FlaxEditor.Modules
         }
 
         /// <summary>
+        /// Resets the selected prefab instance to its default state by deleting it and spawning a fresh copy from the prefab asset.
+        /// </summary>
+        public void ResetPrefab()
+        {
+            // Skip in invalid states
+            if (!Editor.StateMachine.CurrentState.CanEditScene)
+                return;
+
+            var selection = Editor.SceneEditing.Selection.Where(x => x is ActorNode actorNode && actorNode.HasPrefabLink).ToList().BuildNodesParents();
+            if (selection.Count == 0)
+                return;
+
+            var actor = ((ActorNode)selection[0]).Actor;
+            if (!actor || !actor.HasPrefabLink)
+                return;
+
+            // Confirm destructive action
+            if (MessageBox.Show("This will reset the prefab instance to its default state, discarding all overrides. This cannot be undone.\n\nAre you sure?", "Reset Prefab", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
+                return;
+
+            // Find the prefab root
+            var prefabRoot = actor.GetPrefabRoot();
+            if (prefabRoot == null)
+                prefabRoot = actor;
+
+            var prefabId = prefabRoot.PrefabID;
+            var parent = prefabRoot.Parent;
+            var localTransform = prefabRoot.LocalTransform;
+            var name = prefabRoot.Name;
+            var orderInParent = prefabRoot.OrderInParent;
+
+            // Delete the old instance
+            Editor.SceneEditing.Deselect();
+            var scene = prefabRoot.Scene;
+            FlaxEngine.Object.Destroy(prefabRoot);
+            FlaxEngine.Scripting.FlushRemovedObjects();
+
+            // Spawn fresh from prefab
+            var prefab = FlaxEngine.Content.LoadAsync<Prefab>(prefabId);
+            var newActor = PrefabManager.SpawnPrefab(prefab, parent);
+            if (newActor != null)
+            {
+                newActor.LocalTransform = localTransform;
+                newActor.Name = name;
+                newActor.OrderInParent = orderInParent;
+                Editor.Scene.MarkSceneEdited(scene);
+
+                var newNode = SceneGraph.SceneGraphFactory.FindNode(newActor.ID);
+                if (newNode != null)
+                    Editor.SceneEditing.Select(newNode);
+            }
+        }
+
+        /// <summary>
         /// Applies the difference from the prefab object instance, saves the changes and synchronizes them with the active instances of the prefab asset.
         /// </summary>
         /// <remarks>

--- a/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Actions.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FlaxEditor.Actions;
+using FlaxEditor.Content;
+using FlaxEditor.GUI;
 using FlaxEditor.SceneGraph;
 using FlaxEngine;
 using Object = FlaxEngine.Object;
@@ -308,6 +310,155 @@ namespace FlaxEditor.Windows.Assets
 
                 _window = null;
             }
+        }
+
+        /// <summary>
+        /// Resets a nested prefab instance to its default state by deleting it and spawning a fresh copy from the prefab asset.
+        /// </summary>
+        public void ResetNestedPrefab()
+        {
+            if (Selection.Count != 1 || !(Selection[0] is ActorNode actorNode))
+                return;
+
+            var actor = actorNode.Actor;
+            if (!actor.HasPrefabLink)
+                return;
+
+            // Confirm destructive action
+            if (MessageBox.Show("This will reset the nested prefab instance to its default state, discarding all overrides. This cannot be undone.\n\nAre you sure?", "Reset Nested Prefab", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
+                return;
+
+            // Check this actor is part of a nested prefab
+            var prefabObjectId = actor.PrefabObjectID;
+            if (!Asset.GetNestedObject(ref prefabObjectId, out var nestedPrefabId, out _) || nestedPrefabId == Guid.Empty)
+                return;
+
+            // Walk up to find the root of the nested prefab instance:
+            // the highest ancestor still part of the same nested prefab
+            var prefabRoot = actor;
+            var current = actor.Parent;
+            while (current != null && current != Graph.MainActor)
+            {
+                var parentObjectId = current.PrefabObjectID;
+                if (Asset.GetNestedObject(ref parentObjectId, out var parentNestedId, out _) && parentNestedId == nestedPrefabId)
+                {
+                    prefabRoot = current;
+                }
+                else
+                {
+                    break;
+                }
+                current = current.Parent;
+            }
+
+            var parent = prefabRoot.Parent;
+            var localTransform = prefabRoot.LocalTransform;
+            var name = prefabRoot.Name;
+            var orderInParent = prefabRoot.OrderInParent;
+
+            // Deselect
+            var deselectAction = new SelectionChangeAction(Selection.ToArray(), new SceneGraphNode[0], OnSelectionUndo);
+            deselectAction.Do();
+
+            // Delete the old instance (prefab window actors need manual scene graph cleanup)
+            var node = SceneGraphFactory.FindNode(prefabRoot.ID);
+            if (node is ActorNode an)
+                an.Actor.Parent = null;
+            node?.Delete();
+            node?.Dispose();
+            FlaxEngine.Scripting.FlushRemovedObjects();
+
+            // Spawn fresh from the nested prefab
+            var prefab = FlaxEngine.Content.LoadAsync<Prefab>(nestedPrefabId);
+            var newActor = PrefabManager.SpawnPrefab(prefab, parent);
+            if (newActor != null)
+            {
+                newActor.LocalTransform = localTransform;
+                newActor.Name = name;
+                newActor.OrderInParent = orderInParent;
+
+                // Ensure scene graph node exists (LocalSceneGraph.OnActorSpawned should handle this, but be safe)
+                var newNode = SceneGraphFactory.FindNode(newActor.ID) as ActorNode ?? SceneGraphFactory.BuildActorNode(newActor);
+                if (newNode != null)
+                {
+                    var parentNode = SceneGraphFactory.FindNode(parent.ID) as ActorNode;
+                    if (parentNode != null)
+                        newNode.ParentNode = parentNode;
+                    newNode.TreeNode.UnlockChildrenRecursive();
+                    Select(newNode);
+                }
+            }
+
+            MarkAsEdited();
+            _treePanel.PerformLayout();
+        }
+
+        /// <summary>
+        /// Shows a prefab picker, then deletes the selected actor and spawns a fresh instance from the chosen prefab.
+        /// Used when a nested prefab instance has lost its prefab link and can't be auto-detected.
+        /// </summary>
+        public void RelinkToPrefab()
+        {
+            if (Selection.Count != 1 || !(Selection[0] is ActorNode actorNode))
+                return;
+
+            var actor = actorNode.Actor;
+            if (actor == Graph.MainActor)
+                return;
+
+            // Show prefab asset picker
+            AssetSearchPopup.Show(_treePanel, new Float2(_treePanel.Width * 0.5f, _treePanel.Height * 0.5f), item => item is PrefabItem, item =>
+            {
+                // Re-check selection is still valid
+                if (Selection.Count != 1 || !(Selection[0] is ActorNode selectedNode))
+                    return;
+                var targetActor = selectedNode.Actor;
+                if (!targetActor || targetActor == Graph.MainActor)
+                    return;
+
+                // Confirm destructive action
+                if (MessageBox.Show("This will replace the selected actor with a fresh instance from the chosen prefab, discarding all current data. This cannot be undone.\n\nAre you sure?", "Relink to Prefab", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) != DialogResult.OK)
+                    return;
+
+                var parent = targetActor.Parent;
+                var localTransform = targetActor.LocalTransform;
+                var name = targetActor.Name;
+                var orderInParent = targetActor.OrderInParent;
+
+                // Deselect
+                Deselect();
+
+                // Delete the old instance (prefab window actors need manual scene graph cleanup)
+                var node = SceneGraphFactory.FindNode(targetActor.ID);
+                if (node is ActorNode an)
+                    an.Actor.Parent = null;
+                node?.Delete();
+                node?.Dispose();
+                FlaxEngine.Scripting.FlushRemovedObjects();
+
+                // Spawn fresh from the chosen prefab
+                var prefab = FlaxEngine.Content.LoadAsync<Prefab>(item.ID);
+                var newActor = PrefabManager.SpawnPrefab(prefab, parent);
+                if (newActor != null)
+                {
+                    newActor.LocalTransform = localTransform;
+                    newActor.Name = name;
+                    newActor.OrderInParent = orderInParent;
+
+                    var newNode = SceneGraphFactory.FindNode(newActor.ID) as ActorNode ?? SceneGraphFactory.BuildActorNode(newActor);
+                    if (newNode != null)
+                    {
+                        var parentNode = SceneGraphFactory.FindNode(parent.ID) as ActorNode;
+                        if (parentNode != null)
+                            newNode.ParentNode = parentNode;
+                        newNode.TreeNode.UnlockChildrenRecursive();
+                        Select(newNode);
+                    }
+                }
+
+                MarkAsEdited();
+                _treePanel.PerformLayout();
+            });
         }
 
         /// <summary>

--- a/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
+++ b/Source/Editor/Windows/Assets/PrefabWindow.Hierarchy.cs
@@ -328,6 +328,18 @@ namespace FlaxEditor.Windows.Assets
             b = contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);
             b.Enabled = hasPrefabLink;
 
+            bool isNestedPrefab = false;
+            if (hasPrefabLink && isSingleActorSelected && !isRootSelected)
+            {
+                var prefabObjectId = ((ActorNode)Selection[0]).Actor.PrefabObjectID;
+                isNestedPrefab = Asset.GetNestedObject(ref prefabObjectId, out var nestedId, out _) && nestedId != Guid.Empty;
+            }
+            b = contextMenu.AddButton("Reset Prefab (no undo)", ResetNestedPrefab);
+            b.Enabled = isNestedPrefab;
+
+            b = contextMenu.AddButton("Relink to Prefab... (no undo)", RelinkToPrefab);
+            b.Enabled = isSingleActorSelected && !isRootSelected;
+
             // Spawning actors options
 
             contextMenu.AddSeparator();

--- a/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
+++ b/Source/Editor/Windows/SceneTreeWindow.ContextMenu.cs
@@ -148,6 +148,7 @@ namespace FlaxEditor.Windows
                 contextMenu.AddButton("Open Prefab", () => Editor.Prefabs.OpenPrefab(firstSelection));
                 contextMenu.AddButton("Select Prefab", Editor.Prefabs.SelectPrefab);
                 contextMenu.AddButton("Break Prefab Link", Editor.Prefabs.BreakLinks);
+                contextMenu.AddButton("Reset Prefab (no undo)", Editor.Prefabs.ResetPrefab);
             }
 
             // Load additional scenes option


### PR DESCRIPTION
New editor context menu actions to reset a prefab instance to a fresh copy from the source prefab, or relink it to a different prefab. Includes confirmation dialogs since these operations destroy all instance overrides.