### PR TITLE
Patch crashes that cause building projects on linux to fail randomly

### DIFF
--- a/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
@@ -42,6 +42,11 @@ bool LinuxPlatformTools::UseSystemDotnet() const
 bool LinuxPlatformTools::OnDeployBinaries(CookingData& data)
 {
     const auto gameSettings = GameSettings::Get();
+    if (!gameSettings)
+    {
+        data.Error(TEXT("Failed to load game settings."));
+        return true;
+    }
     const auto platformSettings = LinuxPlatformSettings::Get();
     const auto outputPath = data.DataOutputPath;
 

--- a/Source/Editor/Cooker/Steps/DeployDataStep.cpp
+++ b/Source/Editor/Cooker/Steps/DeployDataStep.cpp
@@ -16,8 +16,20 @@ bool DeployDataStep::Perform(CookingData& data)
 {
     data.StepProgress(TEXT("Deploying engine data"), 0);
     const String depsRoot = data.GetPlatformBinariesRoot();
-    const auto& gameSettings = *GameSettings::Get();
-    const auto& buildSettings = *BuildSettings::Get();
+    const auto gameSettingsPtr = GameSettings::Get();
+    if (!gameSettingsPtr)
+    {
+        data.Error(TEXT("Failed to load game settings."));
+        return true;
+    }
+    const auto buildSettingsPtr = BuildSettings::Get();
+    if (!buildSettingsPtr)
+    {
+        data.Error(TEXT("Failed to load build settings."));
+        return true;
+    }
+    const auto& gameSettings = *gameSettingsPtr;
+    const auto& buildSettings = *buildSettingsPtr;
 
     // Setup output folders and copy required data
     const auto contentDir = data.DataOutputPath / TEXT("Content");

--- a/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
+++ b/Source/Engine/GraphicsDevice/Vulkan/GPUContextVulkan.cpp
@@ -463,6 +463,11 @@ void GPUContextVulkan::BeginRenderPass()
     else
     {
         handle = _rtHandles[0];
+        if (!handle)
+        {
+            LOG(Error, "BeginRenderPass called with no render targets bound");
+            return;
+        }
         layout.ReadDepth = false;
         layout.WriteDepth = false;
     }


### PR DESCRIPTION
I don't have a good understanding of the code involved, but this is an attempt to fix some race condition bugs that happen when building projects in Linux. The settings file check just makes the error more visible (the build still fails), but the graphics handle check should allow a build to succeed instead of crashing since it seems to happen during cleanup.