### PR TITLE
Possible fix for race condition crash during shutdown

### DIFF
--- a/Source/Engine/Graphics/Async/GPUTasksContext.cpp
+++ b/Source/Engine/Graphics/Async/GPUTasksContext.cpp
@@ -33,7 +33,7 @@ GPUTasksContext::~GPUTasksContext()
     for (int32 i = 0; i < tasks.Count(); i++)
     {
         auto task = tasks[i];
-        if (task->GetSyncPoint() <= _currentSyncPoint && task->GetState() != TaskState::Finished)
+        if (task->GetState() != TaskState::Finished)
         {
             if (!Engine::IsRequestingExit)
                 LOG(Warning, "'{0}' has been canceled before a sync", task->ToString());


### PR DESCRIPTION
When ~GPUTasksContext() gets called it only calls CancelSync() for tasks it thinks are past the sync frame, but in a race condition that means some tasks don't get canceled. Later on, StreamingTexture::CancelStreamingTasks() runs and tries to cancel those tasks, causing them to crash on accessing the destroyed _context. This sometimes crashes during a linux build for us (even though we're passing -null and -headless anyway). This changes it so destroying GPUTasksContext calls CancelSync() for all unfinished tasks regardless of whether they are past the sync point or not.