### PR TITLE
Log error if platformSettings isn't loaded

### DIFF
--- a/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
+++ b/Source/Editor/Cooker/Platform/Linux/LinuxPlatformTools.cpp
@@ -48,6 +48,11 @@ bool LinuxPlatformTools::OnDeployBinaries(CookingData& data)
         return true;
     }
     const auto platformSettings = LinuxPlatformSettings::Get();
+    if (!platformSettings)
+    {
+        data.Error(TEXT("Failed to load Linux platform settings."));
+        return true;
+    }
     const auto outputPath = data.DataOutputPath;
 
     // Copy binaries


### PR DESCRIPTION
Trying to identify another build crash reason