### PR TITLE
TUI engine

### DIFF
--- a/Source/Engine/Render2D/Font.cpp
+++ b/Source/Engine/Render2D/Font.cpp
@@ -72,6 +72,15 @@ void Font::GetCharacter(Char c, FontCharacterEntry& result, bool enableFallback)
                 if (fallbackFont && fallbackFont->ContainsChar(c))
                 {
                     fallbackFont->CreateFont(GetSize())->GetCharacter(c, result, enableFallback);
+                    // Cache the resolved entry in this font's tables so subsequent lookups skip
+                    // the ContainsChar probe and fallback search. The entry's Font back-pointer
+                    // still references the fallback, so kerning and atlas resolution stay correct.
+                    if (result.IsValid)
+                    {
+                        _characters.Add(c, result);
+                        if (c < 256)
+                            _commonCharacters[c] = result;
+                    }
                     return;
                 }
             }

--- a/Source/Engine/Render2D/Render2D.cpp
+++ b/Source/Engine/Render2D/Render2D.cpp
@@ -1271,6 +1271,90 @@ void Render2D::DrawText(Font* font, const StringView& text, const TextRange& tex
     DrawText(font, textRange.Substring(text), color, location, customMaterial);
 }
 
+void Render2D::DrawTextMonospace(Font* font, const StringView& text, const Color& color, const Float2& location, const Float2& cellAdvance, float scale, MaterialBase* customMaterial)
+{
+    RENDER2D_CHECK_RENDERING_STATE;
+
+    if (font == nullptr ||
+        text.Length() <= 0 ||
+        (customMaterial && (!customMaterial->IsReady() || !customMaterial->IsGUI())))
+        return;
+
+    const float glyphScale = scale / FontManager::FontScale;
+    const bool enableFallbackFonts = EnumHasAllFlags(Features, RenderingFeatures::FallbackFonts);
+    const float baselineY = (font->GetHeight() + font->GetDescender()) * glyphScale;
+
+    uint32 fontAtlasIndex = 0;
+    FontTextureAtlas* fontAtlas = nullptr;
+    Float2 invAtlasSize = Float2::One;
+
+    FontCharacterEntry entry;
+    Render2DDrawCall drawCall;
+    if (customMaterial)
+    {
+        drawCall.Type = DrawCallType::DrawCharMaterial;
+        drawCall.AsChar.Mat = customMaterial;
+    }
+    else
+    {
+        drawCall.Type = DrawCallType::DrawChar;
+        drawCall.AsChar.Mat = nullptr;
+    }
+
+    float cellX = location.X;
+    float cellY = location.Y;
+    for (int32 i = 0; i < text.Length(); i++)
+    {
+        const Char c = text[i];
+
+        // Cheap whitespace fast path: advance the cell cursor and skip the glyph lookup + quad emit
+        // entirely. This is the main win over DrawText for grid text where most cells are blank.
+        if (c == ' ' || c == '\t')
+        {
+            cellX += cellAdvance.X;
+            continue;
+        }
+        if (c == '\n')
+        {
+            cellX = location.X;
+            cellY += cellAdvance.Y;
+            continue;
+        }
+
+        font->GetCharacter(c, entry, enableFallbackFonts);
+
+        if (fontAtlas == nullptr || entry.TextureIndex != fontAtlasIndex)
+        {
+            fontAtlasIndex = entry.TextureIndex;
+            fontAtlas = FontManager::GetAtlas(fontAtlasIndex);
+            if (fontAtlas)
+            {
+                fontAtlas->EnsureTextureCreated();
+                drawCall.AsChar.Tex = fontAtlas->GetTexture();
+                invAtlasSize = 1.0f / fontAtlas->GetSize();
+            }
+            else
+            {
+                drawCall.AsChar.Tex = nullptr;
+                invAtlasSize = 1.0f;
+            }
+        }
+
+        const float x = cellX + entry.OffsetX * glyphScale;
+        const float y = cellY + baselineY - entry.OffsetY * glyphScale;
+        const Rectangle charRect(x, y, entry.UVSize.X * glyphScale, entry.UVSize.Y * glyphScale);
+        const Float2 upperLeftUV = entry.UV * invAtlasSize;
+        const Float2 rightBottomUV = (entry.UV + entry.UVSize) * invAtlasSize;
+
+        drawCall.StartIB = IBIndex;
+        drawCall.CountIB = 6;
+        DrawCalls.Add(drawCall);
+        WriteRect(charRect, color, upperLeftUV, rightBottomUV);
+
+        cellX += cellAdvance.X;
+    }
+}
+
 void Render2D::DrawText(Font* font, const StringView& text, const Color& color, const TextLayoutOptions& layout, MaterialBase* customMaterial)
 {
     RENDER2D_CHECK_RENDERING_STATE;

--- a/Source/Engine/Render2D/Render2D.cpp
+++ b/Source/Engine/Render2D/Render2D.cpp
@@ -1307,8 +1307,7 @@ void Render2D::DrawTextMonospace(Font* font, const StringView& text, const Color
     {
         const Char c = text[i];
 
-        // Cheap whitespace fast path: advance the cell cursor and skip the glyph lookup + quad emit
-        // entirely. This is the main win over DrawText for grid text where most cells are blank.
+        // Early exit for whitespace
         if (c == ' ' || c == '\t')
         {
             cellX += cellAdvance.X;

--- a/Source/Engine/Render2D/Render2D.h
+++ b/Source/Engine/Render2D/Render2D.h
@@ -222,6 +222,19 @@ public:
     API_FUNCTION() static void DrawText(Font* font, const StringView& text, API_PARAM(Ref) const TextRange& textRange, const Color& color, API_PARAM(Ref) const TextLayoutOptions& layout, MaterialBase* customMaterial = nullptr);
 
     /// <summary>
+    /// Draws monospace text using a fixed per-cell advance. Skips kerning lookups and per-glyph advance computation, and emits no draw work for whitespace. Newline ('\n') wraps to the start column on the next row.
+    /// Intended for grid-aligned text (TUI, monospace consoles) where glyphs occupy a single cell; double-width or proportional glyphs will render at the wrong column.
+    /// </summary>
+    /// <param name="font">The font to use. Should be a monospace font.</param>
+    /// <param name="text">The text to render.</param>
+    /// <param name="color">The text color.</param>
+    /// <param name="location">The upper-left location of the first cell.</param>
+    /// <param name="cellAdvance">Per-cell advance in screen pixels: X is the column width, Y is the row height used on '\n'.</param>
+    /// <param name="scale">Glyph metric scale, multiplied on top of the global font scale. Use this to render glyphs larger or smaller than the font's nominal size while keeping cellAdvance fixed.</param>
+    /// <param name="customMaterial">The custom material for font characters rendering. It must contain texture parameter named Font used to sample font texture.</param>
+    API_FUNCTION() static void DrawTextMonospace(Font* font, const StringView& text, const Color& color, const Float2& location, const Float2& cellAdvance, float scale = 1.0f, MaterialBase* customMaterial = nullptr);
+
+    /// <summary>
     /// Fills a rectangle area.
     /// </summary>
     /// <param name="rect">The rectangle to fill.</param>


### PR DESCRIPTION
This is a bug fix to the font engine to cache fallback font characters, so they don't constantly fallback. 

 Measured impact in derelict: mean UIOverlay::Render 1.28ms → 0.64ms
 
 We also have added a cheaper fontdraw method for monospace fonts. 
 
 