### PR TITLE
RaycastAll can optionally hit multiple targets

### DIFF
--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2209,6 +2209,21 @@ bool PhysicsBackend::RayCastAll(void* scene, const Vector3& origin, const Vector
     return true;
 }
 
+bool PhysicsBackend::RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
+{
+    SCENE_QUERY_SETUP(false);
+    DynamicHitBuffer<PxRaycastHit> buffer;
+    auto flags = SCENE_QUERY_FLAGS;
+    if (hitMultiple)
+    {
+        flags |= PxHitFlag::eMESH_MULTIPLE;
+    }
+    if (!scenePhysX->Scene->raycast(C2P(origin - scenePhysX->Origin), C2P(direction), maxDistance, buffer, flags, filterData, &QueryFilter))
+        return false;
+    SCENE_QUERY_COLLECT_ALL();
+    return true;
+}
+
 bool PhysicsBackend::BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
     SCENE_QUERY_SETUP_SWEEP_1();

--- a/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
+++ b/Source/Engine/Physics/PhysX/PhysicsBackendPhysX.cpp
@@ -2209,21 +2209,6 @@ bool PhysicsBackend::RayCastAll(void* scene, const Vector3& origin, const Vector
     return true;
 }
 
-bool PhysicsBackend::RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
-{
-    SCENE_QUERY_SETUP(false);
-    DynamicHitBuffer<PxRaycastHit> buffer;
-    auto flags = SCENE_QUERY_FLAGS;
-    if (hitMultiple)
-    {
-        flags |= PxHitFlag::eMESH_MULTIPLE;
-    }
-    if (!scenePhysX->Scene->raycast(C2P(origin - scenePhysX->Origin), C2P(direction), maxDistance, buffer, flags, filterData, &QueryFilter))
-        return false;
-    SCENE_QUERY_COLLECT_ALL();
-    return true;
-}
-
 bool PhysicsBackend::BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
     SCENE_QUERY_SETUP_SWEEP_1();

--- a/Source/Engine/Physics/Physics.cpp
+++ b/Source/Engine/Physics/Physics.cpp
@@ -308,10 +308,10 @@ bool Physics::RayCast(const Vector3& origin, const Vector3& direction, RayCastHi
     return DefaultScene->RayCast(origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
-bool Physics::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
+bool Physics::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
 {
     CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
-    return DefaultScene->RayCastAll(origin, direction, results, maxDistance, layerMask, hitTriggers);
+    return DefaultScene->RayCastAll(origin, direction, results, maxDistance, layerMask, hitTriggers, hitMultiple);
 }
 
 bool Physics::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
@@ -599,10 +599,10 @@ bool PhysicsScene::RayCast(const Vector3& origin, const Vector3& direction, RayC
     return PhysicsBackend::RayCast(_scene, origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
-bool PhysicsScene::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
+bool PhysicsScene::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
 {
     CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
-    return PhysicsBackend::RayCastAll(_scene, origin, direction, results, maxDistance, layerMask, hitTriggers);
+    return PhysicsBackend::RayCastAll(_scene, origin, direction, results, maxDistance, layerMask, hitTriggers, hitMultiple);
 }
 
 bool PhysicsScene::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)

--- a/Source/Engine/Physics/Physics.cpp
+++ b/Source/Engine/Physics/Physics.cpp
@@ -308,10 +308,10 @@ bool Physics::RayCast(const Vector3& origin, const Vector3& direction, RayCastHi
     return DefaultScene->RayCast(origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
-bool Physics::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
+bool Physics::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
     CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
-    return DefaultScene->RayCastAll(origin, direction, results, maxDistance, layerMask, hitTriggers, hitMultiple);
+    return DefaultScene->RayCastAll(origin, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool Physics::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)
@@ -599,10 +599,10 @@ bool PhysicsScene::RayCast(const Vector3& origin, const Vector3& direction, RayC
     return PhysicsBackend::RayCast(_scene, origin, direction, hitInfo, maxDistance, layerMask, hitTriggers);
 }
 
-bool PhysicsScene::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple)
+bool PhysicsScene::RayCastAll(const Vector3& origin, const Vector3& direction, Array<RayCastHit>& results, const float maxDistance, uint32 layerMask, bool hitTriggers)
 {
     CHECK_RETURN_DEBUG(direction.IsNormalized(), false);
-    return PhysicsBackend::RayCastAll(_scene, origin, direction, results, maxDistance, layerMask, hitTriggers, hitMultiple);
+    return PhysicsBackend::RayCastAll(_scene, origin, direction, results, maxDistance, layerMask, hitTriggers);
 }
 
 bool PhysicsScene::BoxCast(const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, const float maxDistance, uint32 layerMask, bool hitTriggers)

--- a/Source/Engine/Physics/Physics.h
+++ b/Source/Engine/Physics/Physics.h
@@ -169,8 +169,9 @@ public:
     /// <param name="maxDistance">The maximum distance the ray should check for collisions.</param>
     /// <param name="layerMask">The layer mask used to filter the results.</param>
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
+    /// <param name="hitMultiple">If set to <c>true</c> the ray can hit the same collider multiple times.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
-    API_FUNCTION() static bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
+    API_FUNCTION() static bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true, bool hitMultiple = false);
 
     /// <summary>
     /// Performs a sweep test against objects in the scene using a box geometry.

--- a/Source/Engine/Physics/Physics.h
+++ b/Source/Engine/Physics/Physics.h
@@ -169,9 +169,8 @@ public:
     /// <param name="maxDistance">The maximum distance the ray should check for collisions.</param>
     /// <param name="layerMask">The layer mask used to filter the results.</param>
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
-    /// <param name="hitMultiple">If set to <c>true</c> the ray can hit the same collider multiple times.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
-    API_FUNCTION() static bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true, bool hitMultiple = false);
+    API_FUNCTION() static bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
 
     /// <summary>
     /// Performs a sweep test against objects in the scene using a box geometry.

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -123,6 +123,7 @@ public:
     static bool RayCast(void* scene, const Vector3& origin, const Vector3& direction, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool RayCast(void* scene, const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, float maxDistance, uint32 layerMask, bool hitTriggers);
+    static bool RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple);
     static bool BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool BoxCastAll(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);

--- a/Source/Engine/Physics/PhysicsBackend.h
+++ b/Source/Engine/Physics/PhysicsBackend.h
@@ -123,7 +123,6 @@ public:
     static bool RayCast(void* scene, const Vector3& origin, const Vector3& direction, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool RayCast(void* scene, const Vector3& origin, const Vector3& direction, RayCastHit& hitInfo, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, float maxDistance, uint32 layerMask, bool hitTriggers);
-    static bool RayCastAll(void* scene, const Vector3& origin, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, float maxDistance, uint32 layerMask, bool hitTriggers, bool hitMultiple);
     static bool BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool BoxCast(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, RayCastHit& hitInfo, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);
     static bool BoxCastAll(void* scene, const Vector3& center, const Vector3& halfExtents, const Vector3& direction, Array<RayCastHit, HeapAllocation>& results, const Quaternion& rotation, float maxDistance, uint32 layerMask, bool hitTriggers);

--- a/Source/Engine/Physics/PhysicsScene.h
+++ b/Source/Engine/Physics/PhysicsScene.h
@@ -192,7 +192,7 @@ public:
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
     API_FUNCTION() bool RayCast(const Vector3& origin, const Vector3& direction, API_PARAM(Out) RayCastHit& hitInfo, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
-  
+
     /// <summary>
     /// Performs a raycast against objects in the scene, returns results in a RayCastHit structure.
     /// </summary>
@@ -202,9 +202,8 @@ public:
     /// <param name="maxDistance">The maximum distance the ray should check for collisions.</param>
     /// <param name="layerMask">The layer mask used to filter the results.</param>
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
-    /// <param name="hitMultiple">If set to <c>true</c> the ray can hit the same collider multiple times.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
-    API_FUNCTION() bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true, bool hitMultiple = false);
+    API_FUNCTION() bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
 
     /// <summary>
     /// Performs a sweep test against objects in the scene using a box geometry.

--- a/Source/Engine/Physics/PhysicsScene.h
+++ b/Source/Engine/Physics/PhysicsScene.h
@@ -192,7 +192,7 @@ public:
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
     API_FUNCTION() bool RayCast(const Vector3& origin, const Vector3& direction, API_PARAM(Out) RayCastHit& hitInfo, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
-
+  
     /// <summary>
     /// Performs a raycast against objects in the scene, returns results in a RayCastHit structure.
     /// </summary>
@@ -202,8 +202,9 @@ public:
     /// <param name="maxDistance">The maximum distance the ray should check for collisions.</param>
     /// <param name="layerMask">The layer mask used to filter the results.</param>
     /// <param name="hitTriggers">If set to <c>true</c> triggers will be hit, otherwise will skip them.</param>
+    /// <param name="hitMultiple">If set to <c>true</c> the ray can hit the same collider multiple times.</param>
     /// <returns>True if ray hits a matching object, otherwise false.</returns>
-    API_FUNCTION() bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true);
+    API_FUNCTION() bool RayCastAll(const Vector3& origin, const Vector3& direction, API_PARAM(Out) Array<RayCastHit, HeapAllocation>& results, float maxDistance = MAX_float, uint32 layerMask = MAX_uint32, bool hitTriggers = true, bool hitMultiple = false);
 
     /// <summary>
     /// Performs a sweep test against objects in the scene using a box geometry.

--- a/Source/Engine/Renderer/HierarchialZBufferPass.cpp
+++ b/Source/Engine/Renderer/HierarchialZBufferPass.cpp
@@ -28,7 +28,7 @@
 #include "Engine/Input/Input.h"
 
 #define HZB_FORMAT PixelFormat::R32_Float
-#define HZB_BOUNDS_BIAS 10.0f // adds this many pixels to a query objects bounding box on the screen. Increase this to reduce pop-in, at the cost of more conservative occlusion.
+#define HZB_BOUNDS_BIAS 1.0f // adds this many pixels to a query objects bounding box on the screen. Increase this to reduce pop-in, at the cost of more conservative occlusion.
 
 namespace
 {
@@ -497,11 +497,6 @@ void HZBData::CompleteDownload(int64 index)
      if (CurrentFrameIndex < 0) return false;
 
      HZBFrame* activeFrame = &_frames[CurrentFrameIndex % HZB_FRAME_COUNT];
-     
-     if (Vector3::Dot(bounds.Center - activeFrame->ViewPosition, activeFrame->ViewDirection) <= 0.5f)
-     { // camera is facing opposite of the frame
-         return false;
-     }
      // no data yet
      if (activeFrame->TextureData.GetArraySize() == 0)
          return false;
@@ -552,20 +547,13 @@ void HZBData::CompleteDownload(int64 index)
             break;
         }
     }
-    startX = Math::FloorToInt(centerProj.X - radiusLength);
-    endX = Math::CeilToInt(centerProj.X + radiusLength);
-    startY = Math::FloorToInt(centerProj.Y - radiusLength);
-    endY = Math::CeilToInt(centerProj.Y + radiusLength);
-    if ((startX > width - 1 || endX < 0) || (startY > height - 1 || endY < 0))
-    { // bounds were outside the view
-        return false;
-    }
-    startX = Math::Clamp(startX, 0, width - 1);
-    endX = Math::Clamp(endX, 0, width - 1);
+
+    startX = Math::Clamp(Math::FloorToInt(centerProj.X - radiusLength), 0, width - 1);
+    endX = Math::Clamp(Math::CeilToInt(centerProj.X + radiusLength), 0, width - 1);
     startX += offset;
     endX += offset;
-    startY = Math::Clamp(startY, 0, height - 1);
-    endY = Math::Clamp(endY, 0, height - 1);
+    startY = Math::Clamp(Math::FloorToInt(centerProj.Y - radiusLength), 0, height - 1);
+    endY = Math::Clamp(Math::CeilToInt(centerProj.Y + radiusLength), 0, height - 1);
     return true;
 }
 

--- a/Source/Engine/Renderer/HierarchialZBufferPass.cpp
+++ b/Source/Engine/Renderer/HierarchialZBufferPass.cpp
@@ -28,7 +28,7 @@
 #include "Engine/Input/Input.h"
 
 #define HZB_FORMAT PixelFormat::R32_Float
-#define HZB_BOUNDS_BIAS 1.0f // adds this many pixels to a query objects bounding box on the screen. Increase this to reduce pop-in, at the cost of more conservative occlusion.
+#define HZB_BOUNDS_BIAS 10.0f // adds this many pixels to a query objects bounding box on the screen. Increase this to reduce pop-in, at the cost of more conservative occlusion.
 
 namespace
 {
@@ -497,6 +497,11 @@ void HZBData::CompleteDownload(int64 index)
      if (CurrentFrameIndex < 0) return false;
 
      HZBFrame* activeFrame = &_frames[CurrentFrameIndex % HZB_FRAME_COUNT];
+     
+     if (Vector3::Dot(bounds.Center - activeFrame->ViewPosition, activeFrame->ViewDirection) <= 0.5f)
+     { // camera is facing opposite of the frame
+         return false;
+     }
      // no data yet
      if (activeFrame->TextureData.GetArraySize() == 0)
          return false;
@@ -547,13 +552,20 @@ void HZBData::CompleteDownload(int64 index)
             break;
         }
     }
-
-    startX = Math::Clamp(Math::FloorToInt(centerProj.X - radiusLength), 0, width - 1);
-    endX = Math::Clamp(Math::CeilToInt(centerProj.X + radiusLength), 0, width - 1);
+    startX = Math::FloorToInt(centerProj.X - radiusLength);
+    endX = Math::CeilToInt(centerProj.X + radiusLength);
+    startY = Math::FloorToInt(centerProj.Y - radiusLength);
+    endY = Math::CeilToInt(centerProj.Y + radiusLength);
+    if ((startX > width - 1 || endX < 0) || (startY > height - 1 || endY < 0))
+    { // bounds were outside the view
+        return false;
+    }
+    startX = Math::Clamp(startX, 0, width - 1);
+    endX = Math::Clamp(endX, 0, width - 1);
     startX += offset;
     endX += offset;
-    startY = Math::Clamp(Math::FloorToInt(centerProj.Y - radiusLength), 0, height - 1);
-    endY = Math::Clamp(Math::CeilToInt(centerProj.Y + radiusLength), 0, height - 1);
+    startY = Math::Clamp(startY, 0, height - 1);
+    endY = Math::Clamp(endY, 0, height - 1);
     return true;
 }
 


### PR DESCRIPTION
This allows Physics.RayCastAll to specify the `hitMultiple` parameter (false by default). This allows a raycast to hit the same collider multiple times.

I added this for SDF generation.

I also have a minor HZB tweak in there.