### PR TITLE
Remove a redundant buffer resize

### DIFF
--- a/Source/Engine/Graphics/RenderTask.cpp
+++ b/Source/Engine/Graphics/RenderTask.cpp
@@ -19,8 +19,6 @@
 #include "Engine/Threading/Threading.h"
 #if USE_EDITOR
 #include "Engine/Renderer/Lightmaps.h"
-#else
-#include "Engine/Engine/Screen.h"
 #endif
 
 Array<RenderTask*> RenderTask::Tasks;
@@ -471,12 +469,7 @@ void MainRenderTask::OnBegin(GPUContext* context)
     // Use the main camera for the game (can be later overriden in Begin event by external code)
     Camera = Camera::GetMainCamera();
 
-#if !USE_EDITOR
-    // Sync render buffers size with the backbuffer
-    const auto size = Screen::GetSize();
-    Buffers->Init((int32)(size.X * RenderingPercentage), (int32)(size.Y * RenderingPercentage));
-#endif
-
+    // Render buffers are sized by SceneRenderTask::OnBegin from SwapChain/Output (the source of truth)
     SceneRenderTask::OnBegin(context);
 }
 


### PR DESCRIPTION
On cookout there is a duplicate resize buffer that was a performance issue, removing this is both correct and faster . (it's been fully tested)

The follow-up Buffers->Init(...) that makes this change correct lives in SceneRenderTask::OnBegin at Source/Engine/Graphics/RenderTask.cpp:388-396.