### PR TITLE
Fix/prefab nested ref null

### DIFF
--- a/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
+++ b/Source/Editor/CustomEditors/Dedicated/ActorEditor.cs
@@ -206,6 +206,9 @@ namespace FlaxEditor.CustomEditors.Dedicated
                 if (Values != null && prefab && !prefab.WaitForLoaded())
                 {
                     var actor = (Actor)Values[0];
+                    // Instance can be destroyed+rebuilt during apply (eg nested prefab instance) - skip, layout rebuilds anyway
+                    if (!actor)
+                        return;
                     var prefabObjectId = actor.PrefabObjectID;
                     var prefabInstance = prefab.GetDefaultInstance(ref prefabObjectId);
                     if (prefabInstance != null)

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -1027,9 +1027,8 @@ bool Prefab::ApplyAllInternal(Actor* targetActor, bool linkTargetActorObjectToPr
             obj->RegisterObject();
         }
 
-        // Generate nested prefab instances to properly handle Ids Mapping within each nested prefab.
-        // Use the prefab data (the source sceneObjects were spawned from) so SceneObjects[i] and Data[i] stay index-aligned.
-        // The target instance data has a different object set/order (eg. after object deletes) which mismaps nested ids.
+        // Setup nested prefab instances for Ids Mapping. Use prefab data (what sceneObjects were spawned from)
+        // so SceneObjects[i] and Data[i] stay aligned (instance data differs after add/delete and mismaps ids).
         if (NestedPrefabs.HasItems())
         {
             SceneObjectsFactory::PrefabSyncData prefabSyncData(*sceneObjects.Value, data, modifier.Value);
@@ -1037,12 +1036,8 @@ bool Prefab::ApplyAllInternal(Actor* targetActor, bool linkTargetActorObjectToPr
 
             if (context.Instances.HasItems())
             {
-                // Use only nested prefab instance mappings: trash the main instance's own ids
-                // mapping (it would remap this prefab's own objects) but keep every other prefab
-                // instance and its nested mappings. A prefab can hold many instances of the same
-                // nested prefab (eg. doors that each nest the same button prefab); discarding all
-                // but Instances[0] collapsed their shared prefab-object-ids onto one instance.
-                // Per-object IdsMappingScope isolation keeps the kept instances from leaking.
+                // Trash only the main instance's ids mapping (it would remap this prefab's own objects); keep
+                // every nested instance. Discarding the rest collapsed repeated nested prefabs onto one (eg. doors).
                 for (auto& instance : context.Instances)
                 {
                     if (instance.RootIndex == 0)

--- a/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
+++ b/Source/Engine/Level/Prefabs/Prefab.Apply.cpp
@@ -1027,26 +1027,27 @@ bool Prefab::ApplyAllInternal(Actor* targetActor, bool linkTargetActorObjectToPr
             obj->RegisterObject();
         }
 
-        // Generate nested prefab instances to properly handle Ids Mapping within each nested prefab
-        rapidjson_flax::Document targetDataDocument;
+        // Generate nested prefab instances to properly handle Ids Mapping within each nested prefab.
+        // Use the prefab data (the source sceneObjects were spawned from) so SceneObjects[i] and Data[i] stay index-aligned.
+        // The target instance data has a different object set/order (eg. after object deletes) which mismaps nested ids.
         if (NestedPrefabs.HasItems())
         {
-            targetDataDocument.Parse(dataBuffer.GetString(), dataBuffer.GetSize());
-            SceneObjectsFactory::PrefabSyncData prefabSyncData(*sceneObjects.Value, targetDataDocument, modifier.Value);
+            SceneObjectsFactory::PrefabSyncData prefabSyncData(*sceneObjects.Value, data, modifier.Value);
             SceneObjectsFactory::SetupPrefabInstances(context, prefabSyncData);
 
             if (context.Instances.HasItems())
             {
-                // Only main prefab instance is allowed (in case nested prefab was added to this prefab)
-                for (auto i = context.ObjectToInstance.Begin(); i.IsNotEnd(); ++i)
+                // Use only nested prefab instance mappings: trash the main instance's own ids
+                // mapping (it would remap this prefab's own objects) but keep every other prefab
+                // instance and its nested mappings. A prefab can hold many instances of the same
+                // nested prefab (eg. doors that each nest the same button prefab); discarding all
+                // but Instances[0] collapsed their shared prefab-object-ids onto one instance.
+                // Per-object IdsMappingScope isolation keeps the kept instances from leaking.
+                for (auto& instance : context.Instances)
                 {
-                    if (i->Value != 0)
-                        context.ObjectToInstance.Remove(i);
+                    if (instance.RootIndex == 0)
+                        instance.IdsMapping.Clear();
                 }
-                context.Instances.Resize(1);
-
-                // Trash object mapping to prevent messing up prefab structure when applying hierarchy changes (only nested instances are used)
-                context.Instances[0].IdsMapping.Clear();
             }
         }
 

--- a/Source/Engine/Serialization/Serialization.cpp
+++ b/Source/Engine/Serialization/Serialization.cpp
@@ -401,9 +401,7 @@ void Serialization::Deserialize(ISerializable::DeserializeStream& stream, Varian
 
 bool Serialization::ShouldSerialize(const Guid& v, const void* otherObj)
 {
-    // Compare against default rather than just checking IsValid(), so that an
-    // Empty Guid override on a prefab instance is correctly serialized as a diff.
-    // Without this, clearing a Guid field on an instance silently reverts on reload.
+    // Compare against default (not just IsValid) so an Empty Guid override on an instance serializes as a diff (else clearing a ref reverts on reload).
     if (!otherObj)
         return true;
     return v != *(Guid*)otherObj;

--- a/Source/Engine/Serialization/Serialization.cpp
+++ b/Source/Engine/Serialization/Serialization.cpp
@@ -814,6 +814,12 @@ bool Serialization::ShouldSerializeRef(const SceneObject* v, const SceneObject* 
         // In that case, skip saving reference as it's defined in prefab (will be populated via IdsMapping during deserialization)
         result = v->GetPrefabObjectID() != other->GetPrefabObjectID();
     }
+    else if (result && !v && other && other->HasPrefabLink())
+    {
+        // Special case when the reference is null but the prefab defines a reference to a prefab object
+        // In that case, skip saving the null override as it's defined in prefab (might have just failed to resolve via IdsMapping in nested/duplicated prefab instances)
+        result = false;
+    }
     return result;
 }
 


### PR DESCRIPTION
OK! this pull request fixes a long standing bug we've had which has made editing ships and prefabs incredibly brittle. 

The prefab "apply" path had  two faults. 

First, after deleting objects, the rebuild walked the parts and descriptions lists out of sync, so references below a deletion got nulled.

Second, it built a correct ID-mapping per nested prefab instance, then discarded all but the first (Instances.Resize(1)), so repeated instances of the same nested prefab (e.g. many doors sharing one button prefab) collapsed onto one.

this isn't fixed in 1.12, so i can apply this there too. 