### PR TITLE
Medpole tonemapper + jsonfix + skinned mesh prewarm fix. 

### DIFF
--- a/Content/Shaders/ColorGrading.flax
+++ b/Content/Shaders/ColorGrading.flax
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:432adfe36519dfba1e92e0097986b762fa58e9061d64be002cf1d2c3672a4fe5
-size 13819
+oid sha256:a33846b16edd5484c42a585ed207c3c521c0b89d2649ace5de614c28040b510b
+size 15390

--- a/Source/Engine/Graphics/PostProcessSettings.cpp
+++ b/Source/Engine/Graphics/PostProcessSettings.cpp
@@ -69,6 +69,10 @@ void ToneMappingSettings::BlendWith(ToneMappingSettings& other, float weight)
     BLEND_FLOAT(WhiteTemperature);
     BLEND_FLOAT(WhiteTint);
     BLEND_ENUM(Mode);
+    BLEND_FLOAT(Toe);
+    BLEND_FLOAT(Shoulder);
+    BLEND_FLOAT(Saturation);
+    BLEND_FLOAT(PathToWhite);
 }
 
 void ColorGradingSettings::BlendWith(ColorGradingSettings& other, float weight)

--- a/Source/Engine/Graphics/PostProcessSettings.cs
+++ b/Source/Engine/Graphics/PostProcessSettings.cs
@@ -21,4 +21,12 @@ namespace FlaxEngine
         /// </summary>
         public bool ShowTAASettings => (Mode == AntialiasingMode.TemporalAntialiasing);
     }
+
+    public partial struct ToneMappingSettings
+    {
+        /// <summary>
+        /// Whether or not to show the Medpole tonemapper settings.
+        /// </summary>
+        public bool ShowMedpoleSettings => (Mode == ToneMappingMode.Medpole);
+    }
 }

--- a/Source/Engine/Graphics/PostProcessSettings.h
+++ b/Source/Engine/Graphics/PostProcessSettings.h
@@ -59,9 +59,9 @@ API_ENUM() enum class ToneMappingMode
     AGX = 3,
 
     /// <summary>
-    /// The Smoothstep tonemapper.
+    /// The Medpole tonemapper. An analytic, in-gamut-by-construction rational tone curve with artist controls (toe, shoulder, saturation, path-to-white).
     /// </summary>
-    Smoothstep = 4,
+    Medpole = 4,
 };
 
 /// <summary>
@@ -665,9 +665,29 @@ API_ENUM(Attributes ="Flags") enum class ToneMappingSettingsOverride : int32
     Mode = 1 << 2,
 
     /// <summary>
+    /// Overrides <see cref="ToneMappingSettings.Toe"/> property.
+    /// </summary>
+    Toe = 1 << 3,
+
+    /// <summary>
+    /// Overrides <see cref="ToneMappingSettings.Shoulder"/> property.
+    /// </summary>
+    Shoulder = 1 << 4,
+
+    /// <summary>
+    /// Overrides <see cref="ToneMappingSettings.Saturation"/> property.
+    /// </summary>
+    Saturation = 1 << 5,
+
+    /// <summary>
+    /// Overrides <see cref="ToneMappingSettings.PathToWhite"/> property.
+    /// </summary>
+    PathToWhite = 1 << 6,
+
+    /// <summary>
     /// All properties.
     /// </summary>
-    All = WhiteTemperature | WhiteTint | Mode,
+    All = WhiteTemperature | WhiteTint | Mode | Toe | Shoulder | Saturation | PathToWhite,
 };
 
 /// <summary>
@@ -702,6 +722,30 @@ API_STRUCT() struct FLAXENGINE_API ToneMappingSettings : ISerializable
     /// </summary>
     API_FIELD(Attributes="EditorOrder(2), PostProcessSetting((int)ToneMappingSettingsOverride.Mode)")
     ToneMappingMode Mode = ToneMappingMode::ACES;
+
+    /// <summary>
+    /// Medpole tonemapper: shadow toe / contrast. 0 = Reinhard rolloff; increasing values crush shadows toward a quadratic toe. Only used when <see cref="Mode"/> is <see cref="ToneMappingMode.Medpole"/>.
+    /// </summary>
+    API_FIELD(Attributes="Limit(0, 1, 0.001f), EditorOrder(3), PostProcessSetting((int)ToneMappingSettingsOverride.Toe), VisibleIf(nameof(ShowMedpoleSettings))")
+    float Toe = 0.0f;
+
+    /// <summary>
+    /// Medpole tonemapper: highlight rolloff. Adds a cubic term so highlights reach white sooner, concentrated at high brightness. Only used when <see cref="Mode"/> is <see cref="ToneMappingMode.Medpole"/>.
+    /// </summary>
+    API_FIELD(Attributes="Limit(0, 1, 0.001f), EditorOrder(4), PostProcessSetting((int)ToneMappingSettingsOverride.Shoulder), VisibleIf(nameof(ShowMedpoleSettings))")
+    float Shoulder = 0.0f;
+
+    /// <summary>
+    /// Medpole tonemapper: saturation gain. Below 1 desaturates, 1 is native, above 1 boosts saturation up to the gamut hull (hue-locked, never channel-clipped). Only used when <see cref="Mode"/> is <see cref="ToneMappingMode.Medpole"/>.
+    /// </summary>
+    API_FIELD(Attributes="Limit(0, 2, 0.001f), EditorOrder(5), PostProcessSetting((int)ToneMappingSettingsOverride.Saturation), VisibleIf(nameof(ShowMedpoleSettings))")
+    float Saturation = 1.0f;
+
+    /// <summary>
+    /// Medpole tonemapper: path-to-white strength. Controls how much highlights desaturate toward white as they compress. 1 is the validated neutral; 0 disables the path-to-white. Only used when <see cref="Mode"/> is <see cref="ToneMappingMode.Medpole"/>.
+    /// </summary>
+    API_FIELD(Attributes="Limit(0, 1, 0.001f), EditorOrder(6), PostProcessSetting((int)ToneMappingSettingsOverride.PathToWhite), VisibleIf(nameof(ShowMedpoleSettings))")
+    float PathToWhite = 1.0f;
 
 public:
     /// <summary>

--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -116,6 +116,9 @@ AnimatedModel::AnimatedModel(const SpawnParams& params)
 
 AnimatedModel::~AnimatedModel()
 {
+    // Cancel any pending prewarm: actors destroyed without EndPlay (e.g. scripts recompile, async model load
+    // outside play) would otherwise leave a dangling &_skinningData in the render thread's prewarm queue.
+    SkinningPass::Instance()->CancelPrewarm(&_skinningData);
     // Detach any sockets that didn't get OnParentChanged on destruction
     for (BoneSocket* socket : _sockets)
         socket->_parent = nullptr;

--- a/Source/Engine/Renderer/ColorGradingPass.cpp
+++ b/Source/Engine/Renderer/ColorGradingPass.cpp
@@ -37,6 +37,11 @@ GPU_CB_STRUCT(Data{
 
     float ColorVibrance;
     float LutWeight;
+    float ToneToe;
+    float ToneShoulder;
+
+    float ToneSaturation;
+    float TonePathToWhite;
     Float2 Dummy;
 
     void Init(const PostProcessSettings& settings, GPUTexture*& lut)
@@ -47,6 +52,11 @@ GPU_CB_STRUCT(Data{
         // White Balance
         WhiteTemp = toneMapping.WhiteTemperature;
         WhiteTint = toneMapping.WhiteTint;
+        // Tone Mapping (Medpole)
+        ToneToe = toneMapping.Toe;
+        ToneShoulder = toneMapping.Shoulder;
+        ToneSaturation = toneMapping.Saturation;
+        TonePathToWhite = toneMapping.PathToWhite;
         // Shadows
         ColorSaturationShadows = colorGrading.ColorSaturationShadows * colorGrading.ColorSaturation;
         ColorContrastShadows = colorGrading.ColorContrastShadows * colorGrading.ColorContrast;

--- a/Source/Engine/Serialization/JsonSerializer.cs
+++ b/Source/Engine/Serialization/JsonSerializer.cs
@@ -307,6 +307,20 @@ namespace FlaxEngine.Json
                 }
                 return true;
             }
+            // Types that serialize as an object but also implement IEnumerable (e.g. a [JsonObject]-marked
+            // collection-like type with extra fields) must be compared by their serialized members, not by
+            // enumeration. Otherwise non-enumerated members are ignored here and silently dropped from prefab
+            // diffs (the parent treats the object as "unchanged" whenever its enumerated items match).
+            if (objA is IEnumerable && Settings.ContractResolver.ResolveContract(objA.GetType()) is JsonObjectContract enumObjContract)
+            {
+                foreach (var property in enumObjContract.Properties)
+                {
+                    var valueProvider = property.ValueProvider;
+                    if (!ValueEquals(valueProvider.GetValue(objA), valueProvider.GetValue(objB)))
+                        return false;
+                }
+                return true;
+            }
             if (objA is IEnumerable aEnumerable && objB is IEnumerable bEnumerable)
             {
                 var aEnumerator = aEnumerable.GetEnumerator();

--- a/Source/Shaders/ColorGrading.shader
+++ b/Source/Shaders/ColorGrading.shader
@@ -37,6 +37,11 @@ float WhiteTint;
 
 float ColorVibrance;
 float LutWeight;
+float ToneToe;
+float ToneShoulder;
+
+float ToneSaturation;
+float TonePathToWhite;
 float2 Dummy;
 META_CB_END
 
@@ -273,12 +278,26 @@ float3 TonemapAGX(float3 linearColor)
 }
 #endif
 
-#ifdef TONE_MAPPING_MODE_SMOOTHSTEP
+#ifdef TONE_MAPPING_MODE_MEDPOLE
 
-float3 TonemapSmoothstep(float3 linearColor)
+// MEDPOLE --  Brightness acts on
+// MAX(R,G,B) via a monotone rational tone curve. decompose -> desaturate-on-compression -> recompose
+// collapses to a branchless form that is IN-GAMUT BY CONSTRUCTION across the full knob range: 
+float3 TonemapMedpole(float3 color)
 {
-    float amount = 6.0f;
-    return (amount * linearColor * linearColor) / (amount * linearColor * linearColor + 1.0);
+    color = max(color, 0.0);                                           // kill negative inputs (the one load-bearing max)
+    float mx = max(color.r, max(color.g, color.b));
+    float mn = min(color.r, min(color.g, color.b));
+    float poly = (1.0 - ToneToe) + mx * (ToneToe + mx * ToneShoulder); // = (1-toe) + toe*mx + shoulder*mx^2, all coeffs >= 0
+    float N = mx * poly;                                              // c1*mx + c2*mx^2 + c3*mx^3, monotone up
+    float den = 1.0 + N;                                             // >= 1: the rational pole, never degenerate
+    float zp = N / den;                                             // tone curve in [0,1)
+    float scale = poly / den;                                      // = zp/mx, finite at mx=0 (-> 1-toe); also compression proxy
+    float roll = 1.0 - TonePathToWhite * (1.0 - scale);           // path-to-white: 1 (shadow) -> 1-pathToWhite (highlight)
+    float w = scale * ToneSaturation * roll;                     // per-pixel desaturation weight
+    float wcap = zp / max(mx - mn, 1e-6);                       // saturation ceiling: keeps the darkest channel >= 0
+    w = min(w, wcap);                                          // inert for sat<=1; pins the sat>1 boost to the gamut hull, hue-locked
+    return max(zp - w * (mx - color), 0.0);                  // recompose; out in [0, zp] -- the max() is now an inert fp guard
 }
 
 #endif
@@ -294,8 +313,8 @@ float3 Tonemap(float3 linearColor)
 	return TonemapACES(linearColor);
 #elif defined(TONE_MAPPING_MODE_AGX)
     return TonemapAGX(linearColor);
-#elif defined(TONE_MAPPING_MODE_SMOOTHSTEP)
-    return TonemapSmoothstep(linearColor);
+#elif defined(TONE_MAPPING_MODE_MEDPOLE)
+    return TonemapMedpole(linearColor);
 #else
 	return float3(0, 0, 0);
 #endif
@@ -390,7 +409,7 @@ META_PERMUTATION_1(TONE_MAPPING_MODE_NONE=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NEUTRAL=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_ACES=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_AGX=1)
-META_PERMUTATION_1(TONE_MAPPING_MODE_SMOOTHSTEP=1)
+META_PERMUTATION_1(TONE_MAPPING_MODE_MEDPOLE=1)
 float4 PS_Lut2D(Quad_VS2PS input) : SV_Target
 {
 	return CombineLUTs(input.TexCoord, 0);
@@ -401,7 +420,7 @@ META_PERMUTATION_1(TONE_MAPPING_MODE_NONE=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_NEUTRAL=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_ACES=1)
 META_PERMUTATION_1(TONE_MAPPING_MODE_AGX=1)
-META_PERMUTATION_1(TONE_MAPPING_MODE_SMOOTHSTEP=1)
+META_PERMUTATION_1(TONE_MAPPING_MODE_MEDPOLE=1)
 float4 PS_Lut3D(Quad_GS2PS input) : SV_Target
 {
 	return CombineLUTs(input.Vertex.TexCoord, input.LayerIndex);


### PR DESCRIPTION
This adds my new custom tonemapper, the json fix for properties, and fixes a crash bug that happens when you rebuild c# while engine is running from skinned mesh compute prewarm. 