### PR TITLE
Compute shader bug fixes

### DIFF
--- a/Source/Engine/Level/Actors/AnimatedModel.cpp
+++ b/Source/Engine/Level/Actors/AnimatedModel.cpp
@@ -49,50 +49,53 @@ public:
     void PostDraw(GPUContext* context, RenderContextBatch& renderContextBatch) override
     {
         const int32 count = Items.Count();
-        if (count == 0)
-            return;
-        PROFILE_GPU_CPU_NAMED("Update Bones");
-        GPUMemoryPass pass(context);
-        Item* items = Items.Get();
-
-        // Special case for D3D11 backend that doesn't need transitions
-        if (context->GetDevice()->GetRendererType() <= RendererType::DirectX11)
+        if (count != 0)
         {
-            for (int32 i = 0; i < count; i++)
-            {
-                Item& item = items[i];
-                context->UpdateBuffer(item.BoneMatrices, item.Data, item.Size);
-            }
-        }
-        else
-        {
-            // Batch resource barriers for buffer update
-            for (int32 i = 0; i < count; i++)
-                pass.Transition(items[i].BoneMatrices, GPUResourceAccess::CopyWrite);
+            PROFILE_GPU_CPU_NAMED("Update Bones");
+            GPUMemoryPass pass(context);
+            Item* items = Items.Get();
 
-            // Update all buffers within Memory Pass (no barriers between)
-            for (int32 i = 0; i < count; i++)
+            // Special case for D3D11 backend that doesn't need transitions
+            if (context->GetDevice()->GetRendererType() <= RendererType::DirectX11)
             {
-                Item& item = items[i];
-                context->UpdateBuffer(item.BoneMatrices, item.Data, item.Size);
+                for (int32 i = 0; i < count; i++)
+                {
+                    Item& item = items[i];
+                    context->UpdateBuffer(item.BoneMatrices, item.Data, item.Size);
+                }
             }
+            else
+            {
+                // Batch resource barriers for buffer update
+                for (int32 i = 0; i < count; i++)
+                    pass.Transition(items[i].BoneMatrices, GPUResourceAccess::CopyWrite);
 
-            // Batch resource barriers for reading in Vertex Shader
-            for (int32 i = 0; i < count; i++)
-                pass.Transition(items[i].BoneMatrices, GPUResourceAccess::ShaderReadGraphics);
-        }
+                // Update all buffers within Memory Pass (no barriers between)
+                for (int32 i = 0; i < count; i++)
+                {
+                    Item& item = items[i];
+                    context->UpdateBuffer(item.BoneMatrices, item.Data, item.Size);
+                }
+
+                // Batch resource barriers for reading in Vertex Shader
+                for (int32 i = 0; i < count; i++)
+                    pass.Transition(items[i].BoneMatrices, GPUResourceAccess::ShaderReadGraphics);
+            }
 
 #if COMPILE_WITH_PROFILER
-        // Insert amount of kilobytes of data updated into profiler trace
-        uint32 dataSize = 0;
-        for (int32 i = 0; i < count; i++)
-            dataSize += items[i].Size;
-        ZoneValue(dataSize / 1024);
+            // Insert amount of kilobytes of data updated into profiler trace
+            uint32 dataSize = 0;
+            for (int32 i = 0; i < count; i++)
+                dataSize += items[i].Size;
+            ZoneValue(dataSize / 1024);
 #endif
 
-        Items.Clear();
+            Items.Clear();
+        }
 
-        // Dispatch skinning now: after the bone upload, before any pass samples the output VBs.
+        // Dispatch skinning now: after the bone upload, before any pass samples the output VBs. Runs even
+        // with no bone upload: a dormant skeleton enqueues a dispatch (e.g. first draw of a new LOD slot
+        // after re-appearing from culling) without dirtying bones, so gating this on the upload would drop it.
         SkinningPass::Instance()->FlushPending(context);
     }
 };

--- a/Source/Engine/Renderer/SkinningPass.cpp
+++ b/Source/Engine/Renderer/SkinningPass.cpp
@@ -319,12 +319,10 @@ bool SkinningPass::PrepareForDraw(SkinnedMeshDrawData* skinning, const SkinnedMe
     outVB1 = skinning->OutputVB1[slot];
     outVB2 = (hasVertexColor && slot < skinning->OutputVB2.Count()) ? skinning->OutputVB2[slot] : nullptr;
 
-    // Enqueue only if output is stale (dormant-skip). Stamp version now so same-mesh setups this frame coalesce to one dispatch.
+    // Enqueue if the cached output is stale (dormant-skip). OutputVersion advances only once the dispatch
+    // actually runs (see DispatchOne), so a dropped dispatch retries next frame instead of locking the pose.
     if (skinning->OutputVersion[slot] != skinning->SkinningVersion)
-    {
-        skinning->OutputVersion[slot] = skinning->SkinningVersion;
         _pending.Add({ skinning, mesh, slot });
-    }
 
     return true;
 }
@@ -344,11 +342,14 @@ void SkinningPass::FlushPending(GPUContext* context)
     int32 cbIndex = 0;
     for (const PendingDispatch& p : _pending)
     {
+        // Coalesce: a prior entry this frame (another context drawing the same mesh) already skinned this slot.
+        if (!p.Skinning || p.Skinning->OutputVersion[p.Slot] == p.Skinning->SkinningVersion)
+            continue;
         GPUConstantBuffer* cb = GetOrCreateCB(cbIndex++);
         if (!cb)
             continue;
         DispatchOne(context, p, cb, lastBones);
-        lastBones = p.Skinning ? p.Skinning->BoneMatrices : nullptr;
+        lastBones = p.Skinning->BoneMatrices;
     }
     // Clear bindings once at end of pass; downstream passes rebind what they need.
     context->ResetSR();
@@ -474,4 +475,7 @@ void SkinningPass::DispatchOne(GPUContext* context, const PendingDispatch& p, GP
 
     const uint32 groups = (vertexCount + SKINNING_GROUP_SIZE - 1) / SKINNING_GROUP_SIZE;
     context->Dispatch(_csSkin, groups, 1, 1);
+
+    // Mark the cached output resident only after a real dispatch; the early-outs above leave it stale to retry.
+    p.Skinning->OutputVersion[p.Slot] = p.Skinning->SkinningVersion;
 }


### PR DESCRIPTION
This pull request fixes the bug of poses being incorrect, or missing meshes entirely from compute shader skinning.

Essentially this decouples FlushPending from the bone upload so queued dispatches always submit. Also OutputVersion now advances only after a dispatch actually runs, so any dropped dispatch retries the next frame instead of locking the pose.